### PR TITLE
fix: include <jobsmodel.h> directly to support out-of-tree prefixes

### DIFF
--- a/plugin/smartlauncherbackend.h
+++ b/plugin/smartlauncherbackend.h
@@ -11,7 +11,7 @@
 #include <QObject>
 #include <QVariantMap>
 
-#include <notificationmanager/jobsmodel.h>
+#include <jobsmodel.h>
 
 class QDBusServiceWatcher;
 class QString;


### PR DESCRIPTION
## Problem

`plugin/smartlauncherbackend.h` currently uses
```cpp
#include <notificationmanager/jobsmodel.h>
```

But `LibNotificationManager`'s exported `INTERFACE_INCLUDE_DIRECTORIES` already points at `<prefix>/include/notificationmanager` — i.e. the include path is *relative to that directory*. The current form only resolves when `<prefix>/include` happens to also be on the default compiler search path (i.e. when plasma-workspace is installed into `/usr`).

On systems where plasma-workspace is installed to a non-standard prefix — typical in CI runners, rpmbuild roots, and KDE-CI's `_install/` tree — the build fails with:

```
plugin/smartlauncherbackend.h:14:10: fatal error: notificationmanager/jobsmodel.h: No such file or directory
```

## Fix

Use the path that's actually exported:
```cpp
#include <jobsmodel.h>
```

Verified by inspecting the installed `LibNotificationManagerLibraryTargets.cmake`, which sets:
```
INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/notificationmanager"
```

So the public API expects the consumer to include relative to that directory.

## Testing

Tested on a local out-of-tree build that previously failed; the include change makes it succeed without any other changes. Same code on Plasma 6.6+ with Qt 6.