### PR TITLE
perf: cache KFilePlacesModel as a Backend member

### DIFF
--- a/plugin/backend.cpp
+++ b/plugin/backend.cpp
@@ -251,11 +251,13 @@ QVariantList Backend::placesActions(const QUrl &launcherUrl, bool showAllPlaces,
     QString previousGroup;
     QMenu *subMenu = nullptr;
 
-    std::unique_ptr<KFilePlacesModel> placesModel(new KFilePlacesModel());
-    for (int i = 0; i < placesModel->rowCount(); ++i) {
-        QModelIndex idx = placesModel->index(i, 0);
+    if (!m_placesModel) {
+        m_placesModel = std::make_unique<KFilePlacesModel>();
+    }
+    for (int i = 0; i < m_placesModel->rowCount(); ++i) {
+        QModelIndex idx = m_placesModel->index(i, 0);
 
-        if (placesModel->isHidden(idx)) {
+        if (m_placesModel->isHidden(idx)) {
             continue;
         }
 

--- a/plugin/backend.h
+++ b/plugin/backend.h
@@ -11,9 +11,13 @@
 #include <QObject>
 #include <QRect>
 
+#include <memory>
+
 #include <netwm.h>
 #include <qqmlregistration.h>
 #include <qwindowdefs.h>
+
+class KFilePlacesModel;
 
 #include "kactivitymanagerd_plugins_settings.h"
 
@@ -77,6 +81,10 @@ private:
 
     QActionGroup *m_actionGroup = nullptr;
     KActivities::Consumer *m_activitiesConsumer = nullptr;
+
+    // Cached on first call to placesActions(); KFilePlacesModel internally
+    // watches the user's bookmarks/mounts and keeps itself current.
+    std::unique_ptr<KFilePlacesModel> m_placesModel;
 
     KActivityManagerdPluginsSettings m_activityManagerPluginsSettings;
     KConfigWatcher::Ptr m_activityManagerPluginsSettingsWatcher;


### PR DESCRIPTION
## Problem

`Backend::placesActions()` is invoked every time the right-click context menu is built for a file-manager launcher. It currently does:

```cpp
std::unique_ptr<KFilePlacesModel> placesModel(new KFilePlacesModel());
for (int i = 0; i < placesModel->rowCount(); ++i) {
    ...
}
```

Constructing a fresh `KFilePlacesModel` walks the user's bookmarks, mounts, and KActivities to populate the model. Doing it on every menu open is wasted work.

## Fix

Hold the `KFilePlacesModel` as a unique_ptr member on `Backend`, lazy-initialized on first use. The model watches its underlying sources and keeps itself current, so reusing the same instance is correct and skips the per-menu setup cost.

`plugin/backend.h` gains:
- `#include <memory>`
- a forward declaration `class KFilePlacesModel;`
- a private `std::unique_ptr<KFilePlacesModel> m_placesModel;`

`plugin/backend.cpp`'s `placesActions()` replaces the local instantiation with a lazy-init guard.

## Testing

Built and ran locally on Plasma 6.6+; context-menu places list is identical to before, opens on every right-click as expected, and is responsive to bookmark / mount changes (since `KFilePlacesModel` self-watches).