### PR TITLE
perf: rewrite TaskList.minimumWidth as a single-pass loop

### DIFF
--- a/package/contents/ui/TaskList.qml
+++ b/package/contents/ui/TaskList.qml
@@ -27,9 +27,19 @@ GridLayout {
 
     readonly property bool vertical: Plasmoid.formFactor === PlasmaCore.Types.Vertical
 
-    readonly property real minimumWidth: children
-        .filter(item => item.visible && item.width > 0)
-        .reduce((minimumWidth, item) => Math.min(minimumWidth, item.width), Infinity)
+    // Smallest visible task width; consumed by Task.qml's standalone-icon
+    // state to clamp the icon box. Single-pass over `children` avoids the
+    // intermediate filtered array of the original `.filter().reduce()`.
+    readonly property real minimumWidth: {
+        let min = Infinity;
+        for (let i = 0; i < children.length; ++i) {
+            const item = children[i];
+            if (item.visible && item.width > 0 && item.width < min) {
+                min = item.width;
+            }
+        }
+        return min;
+    }
 
     readonly property int stripeCount: {
         if (Plasmoid.configuration.maxStripes === 1) {


### PR DESCRIPTION
## Problem

`TaskList.qml`'s `minimumWidth` is currently:

```qml
readonly property real minimumWidth: children
    .filter(item => item.visible && item.width > 0)
    .reduce((minimumWidth, item) => Math.min(minimumWidth, item.width), Infinity)
```

Two costs each time this binding evaluates:

1. The QML engine creates dependencies on every child's `visible` and `width` (because the lambda reads those properties), so the binding re-fires whenever *any* child's visibility or width changes — which during zoom animations or layout transitions can be several times per frame.

2. `.filter()` allocates an intermediate JS array each time. With N tasks, that's O(N) garbage per re-evaluation.

## Fix

Rewrite as a single-pass `for` loop with the same semantics:

```qml
readonly property real minimumWidth: {
    let min = Infinity;
    for (let i = 0; i < children.length; ++i) {
        const item = children[i];
        if (item.visible && item.width > 0 && item.width < min) {
            min = item.width;
        }
    }
    return min;
}
```

Same dependency tracking; no intermediate allocation. Result is identical.

## Testing

Built and ran locally; tasks render and zoom identically. Consumer (`Task.qml`'s standalone-icon state at `task.parent.minimumWidth`) behaves the same.