### PR TITLE
chore: add pragma ComponentBehavior: Bound to the remaining QML files

### DIFF
--- a/package/contents/ui/AudioStream.qml
+++ b/package/contents/ui/AudioStream.qml
@@ -4,6 +4,8 @@
     SPDX-License-Identifier: GPL-2.0-or-later
 */
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 
 import org.kde.plasma.plasmoid

--- a/package/contents/ui/Badge.qml
+++ b/package/contents/ui/Badge.qml
@@ -4,6 +4,8 @@
     SPDX-License-Identifier: GPL-2.0-or-later
 */
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 
 import org.kde.plasma.components as PlasmaComponents3

--- a/package/contents/ui/ConfigAppearance.qml
+++ b/package/contents/ui/ConfigAppearance.qml
@@ -4,6 +4,8 @@
     SPDX-License-Identifier: GPL-2.0-or-later
 */
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls as QQC2
 import Qt.labs.folderlistmodel // Importante para listar las carpetas de skins

--- a/package/contents/ui/ConfigBehavior.qml
+++ b/package/contents/ui/ConfigBehavior.qml
@@ -4,6 +4,8 @@
     SPDX-License-Identifier: GPL-2.0-or-later
 */
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls as QQC2
 import QtQuick.Layouts

--- a/package/contents/ui/ContextMenu.qml
+++ b/package/contents/ui/ContextMenu.qml
@@ -5,6 +5,8 @@
     SPDX-License-Identifier: GPL-2.0-or-later
 */
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 
 import org.kde.plasma.plasmoid

--- a/package/contents/ui/GroupExpanderOverlay.qml
+++ b/package/contents/ui/GroupExpanderOverlay.qml
@@ -4,6 +4,8 @@
     SPDX-License-Identifier: GPL-2.0-or-later
 */
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 
 import org.kde.plasma.core as PlasmaCore

--- a/package/contents/ui/MouseHandler.qml
+++ b/package/contents/ui/MouseHandler.qml
@@ -4,6 +4,8 @@
     SPDX-License-Identifier: GPL-2.0-or-later
 */
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 
 import org.kde.taskmanager as TaskManager

--- a/package/contents/ui/PipeWireThumbnail.qml
+++ b/package/contents/ui/PipeWireThumbnail.qml
@@ -4,6 +4,8 @@
     SPDX-License-Identifier: LGPL-2.0-or-later
 */
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import org.kde.pipewire as PipeWire
 import org.kde.taskmanager as TaskManager

--- a/package/contents/ui/TaskBadgeOverlay.qml
+++ b/package/contents/ui/TaskBadgeOverlay.qml
@@ -4,6 +4,8 @@
     SPDX-License-Identifier: GPL-2.0-or-later
 */
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import org.kde.kirigami as Kirigami
 import org.kde.graphicaleffects as KGraphicalEffects

--- a/package/contents/ui/TaskList.qml
+++ b/package/contents/ui/TaskList.qml
@@ -4,6 +4,8 @@
     SPDX-License-Identifier: GPL-2.0-or-later
 */
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Layouts
 

--- a/package/contents/ui/TaskProgressOverlay.qml
+++ b/package/contents/ui/TaskProgressOverlay.qml
@@ -4,6 +4,8 @@
     SPDX-License-Identifier: GPL-2.0-or-later
 */
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Templates as T
 

--- a/package/contents/ui/config.qml
+++ b/package/contents/ui/config.qml
@@ -4,6 +4,8 @@
     SPDX-License-Identifier: GPL-2.0-or-later
 */
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 
 import org.kde.plasma.configuration


### PR DESCRIPTION
## What

Adds `pragma ComponentBehavior: Bound` to the QML files that don't already have it:

- `AudioStream.qml`
- `Badge.qml`
- `ConfigAppearance.qml`
- `ConfigBehavior.qml`
- `config.qml`
- `ContextMenu.qml`
- `GroupExpanderOverlay.qml`
- `MouseHandler.qml`
- `PipeWireThumbnail.qml`
- `TaskBadgeOverlay.qml`
- `TaskList.qml`
- `TaskProgressOverlay.qml`

`main.qml`, `Task.qml`, `ToolTipInstance.qml`, etc. already opt in. This brings the package to 100% coverage.

## Why

`pragma ComponentBehavior: Bound` tells the QML engine that identifiers in delegate scopes are resolved lexically (the delegate's own scope) rather than walking ancestor contexts. Two upsides:

* The engine resolves identifiers at compile time rather than via runtime scope chain lookup, which is measurable on hot paths like per-task delegates that re-evaluate often during zoom animations.

* Any unqualified access that would have silently picked up an outer-scope binding becomes a load-time error instead of a subtle runtime bug.

[Qt 6 docs on the pragma](https://doc.qt.io/qt-6/qtqml-syntax-imports.html#component-behavior).

## Testing

Each file loads cleanly under the pragma — `qmllint` is silent, plasmashell loads the applet without any unqualified-access warnings, and runtime behavior is unchanged.