### PR TITLE
style: probe PulseAudio.qml availability via declarative Component

### DIFF
--- a/package/contents/ui/ConfigAppearance.qml
+++ b/package/contents/ui/ConfigAppearance.qml
@@ -17,7 +17,13 @@ import QtQuick.Layouts
 KCMUtils.SimpleKCM {
     id: root
 
-    readonly property bool plasmaPaAvailable: Qt.createComponent("PulseAudio.qml").status === Component.Ready
+    // Probes whether PulseAudio.qml (which imports org.kde.plasma.private.volume)
+    // can load; controls whether the audio-stream config options are enabled.
+    Component {
+        id: pulseAudioProbe
+        PulseAudio {}
+    }
+    readonly property bool plasmaPaAvailable: pulseAudioProbe.status === Component.Ready
     readonly property bool plasmoidVertical: Plasmoid.formFactor === PlasmaCore.Types.Vertical
     readonly property bool iconOnly: Plasmoid.pluginName === "org.vicko.wavetask"
 


### PR DESCRIPTION
## What

In `ConfigAppearance.qml`, replace:

```qml
readonly property bool plasmaPaAvailable: Qt.createComponent("PulseAudio.qml").status === Component.Ready
```

with:

```qml
Component {
    id: pulseAudioProbe
    PulseAudio {}
}
readonly property bool plasmaPaAvailable: pulseAudioProbe.status === Component.Ready
```

## Why

Two small reasons:

* **String URL → identifier.** `Qt.createComponent("PulseAudio.qml")` looks up a string path with no compile-time check. A rename or typo in `PulseAudio.qml` silently leaves the property always-`false`, which silently disables the audio-stream config controls. The declarative form binds to the `PulseAudio` identifier directly, so a missing/renamed file is a load-time error.

* **Lifetime.** The `Component` returned by `Qt.createComponent` is owned by the engine root and lives until the engine shuts down. In long-running KCMs that's a tiny leak. The declarative form is scoped to the surrounding `KCMUtils.SimpleKCM` and goes away when the KCM closes.

Behavior for consumers (`plasmaPaAvailable` checks at lines 205 and 207) is identical.

## Testing

KCM dialog opens, audio-stream controls enable/disable correctly based on whether `PulseAudio.qml` can load (i.e. whether `org.kde.plasma.private.volume` is available).