### PR TITLE
  feat: show dock and task index numbers on Meta/Win key hold

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -173,6 +173,14 @@
     <entry name="cairoPenguinEnabled" type="Bool">
       <default>false</default>
     </entry>
+    <entry name="showOnMetaKey" type="Bool">
+      <label>Whether pressing the Meta/Win key should temporarily show the dock when it is hidden.</label>
+      <default>true</default>
+    </entry>
+    <entry name="showTaskNumbersOnMeta" type="Bool">
+      <label>Whether holding the Meta/Win key should display task index numbers above each icon.</label>
+      <default>true</default>
+    </entry>
   </group>
 
 </kcfg>

--- a/package/contents/ui/ConfigBehavior.qml
+++ b/package/contents/ui/ConfigBehavior.qml
@@ -37,6 +37,8 @@ KCMUtils.SimpleKCM {
     property alias cfg_showOnlyMinimized: showOnlyMinimized.checked
     property alias cfg_minimizeActiveTaskOnClick: minimizeActive.checked
     property alias cfg_unhideOnAttention: unhideOnAttention.checked
+    property alias cfg_showOnMetaKey: showOnMetaKey.checked
+    property alias cfg_showTaskNumbersOnMeta: showTaskNumbersOnMeta.checked
     property alias cfg_reverseMode: reverseMode.checked
 
     headerPaddingEnabled: false
@@ -261,6 +263,21 @@ KCMUtils.SimpleKCM {
             onToggled: {
                 annoyingAppWorkaroundMessage.visible = !unhideOnAttention.checked;
             }
+        }
+
+        Item {
+            Kirigami.FormData.isSection: true
+        }
+
+        QQC2.CheckBox {
+            id: showOnMetaKey
+            Kirigami.FormData.label: i18nc("@label for checkbox, completes sentence: … show dock when Meta key is pressed", "Meta key:")
+            text: i18nc("@option:check completes sentence: Pressing Meta key", "Shows the dock when it's hidden")
+        }
+
+        QQC2.CheckBox {
+            id: showTaskNumbersOnMeta
+            text: i18nc("@option:check completes sentence: Holding Meta key", "Displays task index numbers on each icon")
         }
 
         Item {

--- a/package/contents/ui/Task.qml
+++ b/package/contents/ui/Task.qml
@@ -790,9 +790,57 @@ PlasmaCore.ToolTipArea {
             }
         }
 
+    // --- META KEY TASK INDEX BADGE ---
+    Item {
+        id: metaIndexBadge
 
+        visible: tasksRoot.metaShowActive && Plasmoid.configuration.showTaskNumbersOnMeta
 
+        // Position depends on panel location:
+        // Bottom panel: above icon; Top panel: below icon
+        // Left panel: right of icon; Right panel: left of icon
+        anchors.horizontalCenter: tasksRoot.vertical ? undefined : iconBox.horizontalCenter
+        anchors.verticalCenter: tasksRoot.vertical ? iconBox.verticalCenter : undefined
 
+        anchors.bottom: tasksRoot.vertical ? undefined
+            : (tasksRoot.isTopPanel ? undefined : iconBox.top)
+        anchors.top: tasksRoot.vertical ? undefined
+            : (tasksRoot.isTopPanel ? iconBox.bottom : undefined)
+        anchors.left: tasksRoot.vertical
+            ? (tasksRoot.isLeftPanel ? iconBox.right : undefined)
+            : undefined
+        anchors.right: tasksRoot.vertical
+            ? (tasksRoot.isLeftPanel ? undefined : iconBox.left)
+            : undefined
+
+        anchors.bottomMargin: (!tasksRoot.vertical && !tasksRoot.isTopPanel) ? 4 : 0
+        anchors.topMargin: (!tasksRoot.vertical && tasksRoot.isTopPanel) ? 4 : 0
+        anchors.leftMargin: (tasksRoot.vertical && tasksRoot.isLeftPanel) ? 4 : 0
+        anchors.rightMargin: (tasksRoot.vertical && !tasksRoot.isLeftPanel) ? 4 : 0
+
+        width: 20
+        height: 20
+        z: 10
+
+        Rectangle {
+            anchors.fill: parent
+            radius: width / 2
+            color: Qt.rgba(0, 0, 0, 0.7)
+            border.color: Qt.rgba(1, 1, 1, 0.5)
+            border.width: 1
+            antialiasing: true
+        }
+
+        PlasmaComponents3.Label {
+            anchors.centerIn: parent
+            text: (task.index + 1).toString()
+            font.pixelSize: 11
+            font.bold: true
+            color: "#ffffff"
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+    }
 
     PlasmaComponents3.Label {
         id: label

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -46,6 +46,48 @@ PlasmoidItem {
     property alias taskList: taskList
     property alias taskRepeater: taskRepeater
 
+    readonly property bool metaKeyHeld: backend.metaKeyHeld
+    readonly property bool metaFeaturesEnabled: Plasmoid.configuration.showOnMetaKey
+                                                || Plasmoid.configuration.showTaskNumbersOnMeta
+
+    // --- META KEY DOCK VISIBILITY ---
+    property bool metaShowActive: false
+
+    // Reset timer: hides dock and numbers after Meta is no longer detected
+    Timer {
+        id: metaResetTimer
+        interval: 500
+        repeat: false
+        onTriggered: {
+            console.log("QML: metaResetTimer fired, hiding dock/numbers");
+            tasks.metaShowActive = false;
+        }
+    }
+
+    // Refresh timer: while Meta is still held, keep restarting the reset timer
+    Timer {
+        id: metaRefreshTimer
+        interval: 200
+        repeat: true
+        running: tasks.metaShowActive
+        onTriggered: {
+            if (backend.metaKeyHeld) {
+                metaResetTimer.restart();
+            }
+        }
+    }
+
+    Connections {
+        target: backend
+        function onMetaKeyHeldChanged() {
+            console.log("QML: onMetaKeyHeldChanged, held=" + backend.metaKeyHeld);
+            if (backend.metaKeyHeld && Plasmoid.configuration.showOnMetaKey) {
+                tasks.metaShowActive = true;
+                metaResetTimer.restart();
+            }
+        }
+    }
+
     readonly property bool isTopPanel: Plasmoid.location === PlasmaCore.Types.TopEdge
     readonly property bool isLeftPanel: Plasmoid.location === PlasmaCore.Types.LeftEdge
 
@@ -441,8 +483,15 @@ PlasmoidItem {
         Binding {
             target: Plasmoid
             property: "status"
-            value: (tasksModel.anyTaskDemandsAttention && Plasmoid.configuration.unhideOnAttention
-                ? PlasmaCore.Types.NeedsAttentionStatus : PlasmaCore.Types.PassiveStatus)
+            value: {
+                if (tasks.metaShowActive) {
+                    return PlasmaCore.Types.NeedsAttentionStatus;
+                }
+                if (tasksModel.anyTaskDemandsAttention && Plasmoid.configuration.unhideOnAttention) {
+                    return PlasmaCore.Types.NeedsAttentionStatus;
+                }
+                return PlasmaCore.Types.PassiveStatus;
+            }
             restoreMode: Binding.RestoreBinding
         }
 

--- a/plugin/backend.cpp
+++ b/plugin/backend.cpp
@@ -42,6 +42,17 @@
 #include <processcore/process.h>
 #include <processcore/processes.h>
 
+#include <QDBusConnection>
+#include <QSocketNotifier>
+#include <QDir>
+#include <QFile>
+#include <QSet>
+
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <linux/input.h>
+
 namespace KAStats = KActivities::Stats;
 
 using namespace KAStats;
@@ -63,11 +74,154 @@ Backend::Backend(QObject *parent)
                     m_activityManagerPluginsSettings.load();
                 }
             });
+
+    // Direct /dev/input keyboard monitoring (instant, no focus dependency)
+    initInputMonitor();
+
+    // Register D-Bus object for external communication
+    QDBusConnection::sessionBus().registerObject(
+        QStringLiteral("/WavetaskMeta"), this, QDBusConnection::ExportScriptableSlots);
+
+    qCWarning(WAVETASK_DEBUG) << "Backend: Meta detection via /dev/input + DBus";
 }
 
 Backend::~Backend()
 {
+    for (auto *notifier : m_inputNotifiers) {
+        delete notifier;
+    }
+    for (int fd : m_inputFds) {
+        close(fd);
+    }
 }
+
+// --- Meta Key Detection ---
+
+bool Backend::isMetaKeyHeld() const
+{
+    return m_metaKeyHeld;
+}
+
+void Backend::setMetaKeyHeld(bool held)
+{
+    if (m_metaKeyHeld != held) {
+        qCWarning(WAVETASK_DEBUG) << "Backend: metaKeyHeld changed to" << held;
+        m_metaKeyHeld = held;
+        Q_EMIT metaKeyHeldChanged();
+    }
+}
+
+// --- /dev/input Keyboard Monitoring ---
+
+void Backend::initInputMonitor()
+{
+    // Scan for keyboard devices once at startup
+    scanInputDevices();
+
+    // Periodically rescan for hotplugged devices
+    m_rescanTimer = new QTimer(this);
+    m_rescanTimer->setInterval(5000);
+    connect(m_rescanTimer, &QTimer::timeout, this, &Backend::scanInputDevices);
+    m_rescanTimer->start();
+}
+
+void Backend::scanInputDevices()
+{
+    QDir inputDir(QStringLiteral("/dev/input"));
+    const auto entries = inputDir.entryList({QStringLiteral("event*")}, QDir::System, QDir::Name);
+
+    // Track already monitored paths to avoid duplicates
+    static QSet<QString> monitoredPaths;
+
+    for (const auto &name : entries) {
+        QString path = inputDir.absoluteFilePath(name);
+
+        if (monitoredPaths.contains(path)) {
+            continue; // Already monitoring this device
+        }
+
+        int fd = open(path.toUtf8().constData(), O_RDONLY | O_NONBLOCK);
+        if (fd < 0) {
+            continue;
+        }
+
+        // Check if this device supports EV_KEY events
+        unsigned long evBits[EV_CNT / (sizeof(unsigned long) * 8) + 1] = {};
+        if (ioctl(fd, EVIOCGBIT(0, sizeof(evBits)), evBits) < 0) {
+            close(fd);
+            continue;
+        }
+
+        if (!(evBits[EV_KEY / (sizeof(unsigned long) * 8)] & (1UL << (EV_KEY % (sizeof(unsigned long) * 8))))) {
+            close(fd);
+            continue;
+        }
+
+        // Check if it has the Meta keys
+        unsigned long keyBits[KEY_CNT / (sizeof(unsigned long) * 8) + 1] = {};
+        if (ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(keyBits)), keyBits) < 0) {
+            close(fd);
+            continue;
+        }
+
+        bool hasLeftMeta = keyBits[KEY_LEFTMETA / (sizeof(unsigned long) * 8)] & (1UL << (KEY_LEFTMETA % (sizeof(unsigned long) * 8)));
+        bool hasRightMeta = keyBits[KEY_RIGHTMETA / (sizeof(unsigned long) * 8)] & (1UL << (KEY_RIGHTMETA % (sizeof(unsigned long) * 8)));
+
+        if (!hasLeftMeta && !hasRightMeta) {
+            close(fd);
+            continue;
+        }
+
+        // This is a keyboard with Meta keys — monitor it
+        auto *notifier = new QSocketNotifier(fd, QSocketNotifier::Read, this);
+        connect(notifier, &QSocketNotifier::activated, this, [this, fd]() {
+            onInputEvent(fd);
+        });
+
+        m_inputFds.append(fd);
+        m_inputNotifiers.append(notifier);
+        monitoredPaths.insert(path);
+
+        qCWarning(WAVETASK_DEBUG) << "Backend: monitoring keyboard" << path
+                                  << "(fd=" << fd << ")";
+    }
+}
+
+void Backend::onInputEvent(int fd)
+{
+    struct input_event ev;
+    while (read(fd, &ev, sizeof(ev)) == sizeof(ev)) {
+        if (ev.type == EV_KEY &&
+            (ev.code == KEY_LEFTMETA || ev.code == KEY_RIGHTMETA)) {
+            if (ev.value == 1) {
+                // Press
+                qCWarning(WAVETASK_DEBUG) << "Backend: Meta pressed (fd=" << fd << ")";
+                setMetaKeyHeld(true);
+            } else if (ev.value == 0) {
+                // Release
+                qCWarning(WAVETASK_DEBUG) << "Backend: Meta released (fd=" << fd << ")";
+                setMetaKeyHeld(false);
+            }
+            // value == 2 (auto-repeat): ignored for modifier keys
+        }
+    }
+}
+
+// --- End Input Monitor ---
+
+void Backend::metaKeyPressed()
+{
+    qCWarning(WAVETASK_DEBUG) << "Backend: D-Bus metaKeyPressed called";
+    setMetaKeyHeld(true);
+}
+
+void Backend::metaKeyReleased()
+{
+    qCWarning(WAVETASK_DEBUG) << "Backend: D-Bus metaKeyReleased called";
+    setMetaKeyHeld(false);
+}
+
+// --- End Meta Key Detection ---
 
 void Backend::setBlurBehind(QWindow *window, bool enable, int x, int y, int w, int h, int radius)
 {

--- a/plugin/backend.cpp
+++ b/plugin/backend.cpp
@@ -9,32 +9,26 @@
 #include "log_settings.h"
 #include <KConfigGroup>
 #include <KDesktopFile>
-#include <KFileItem>
 #include <KFilePlacesModel>
 #include <KLocalizedString>
 #include <KNotificationJobUiDelegate>
-#include <KProtocolInfo>
 #include <KService>
 #include <KServiceAction>
 #include <KWindowEffects>
-#include <KWindowSystem>
 
 #include <KApplicationTrader>
 #include <KIO/ApplicationLauncherJob>
+#include <KIO/Global>
 
 #include <QAction>
 #include <QActionGroup>
-#include <QApplication>
-#include <QJsonArray>
 #include <QMenu>
 #include <QQuickItem>
 #include <QQuickWindow>
 #include <QStandardPaths>
 #include <QTimer>
-#include <QVersionNumber>
 #include <QWindow>
 
-#include <PlasmaActivities/Consumer>
 #include <PlasmaActivities/Stats/Cleaning>
 #include <PlasmaActivities/Stats/ResultSet>
 #include <PlasmaActivities/Stats/Terms>
@@ -45,7 +39,6 @@
 #include <QDBusConnection>
 #include <QSocketNotifier>
 #include <QDir>
-#include <QFile>
 #include <QSet>
 
 #include <fcntl.h>

--- a/plugin/backend.h
+++ b/plugin/backend.h
@@ -22,6 +22,7 @@ class QActionGroup;
 class QQuickItem;
 class QQuickWindow;
 class QJsonArray;
+class QSocketNotifier;
 class QWindow;
 
 namespace KActivities
@@ -33,6 +34,7 @@ class Backend : public QObject
 {
     Q_OBJECT
     QML_ELEMENT
+    Q_CLASSINFO("D-Bus Interface", "org.kde.plasmashell.WavetaskMeta")
 
 public:
     enum MiddleClickAction {
@@ -45,6 +47,8 @@ public:
     };
 
     Q_ENUM(MiddleClickAction)
+
+    Q_PROPERTY(bool metaKeyHeld READ isMetaKeyHeld NOTIFY metaKeyHeldChanged)
 
     explicit Backend(QObject *parent = nullptr);
     ~Backend() override;
@@ -64,10 +68,17 @@ public:
     Q_INVOKABLE static QUrl tryDecodeApplicationsUrl(const QUrl &launcherUrl);
     Q_INVOKABLE static QStringList applicationCategories(const QUrl &launcherUrl);
 
+    bool isMetaKeyHeld() const;
+
 Q_SIGNALS:
     void addLauncher(const QUrl &url) const;
 
     void showAllPlaces();
+    void metaKeyHeldChanged();
+
+public Q_SLOTS:
+    Q_SCRIPTABLE void metaKeyPressed();
+    Q_SCRIPTABLE void metaKeyReleased();
 
 private Q_SLOTS:
     void handleRecentDocumentAction() const;
@@ -80,4 +91,15 @@ private:
 
     KActivityManagerdPluginsSettings m_activityManagerPluginsSettings;
     KConfigWatcher::Ptr m_activityManagerPluginsSettingsWatcher;
+
+    // Meta key detection via /dev/input monitoring
+    void setMetaKeyHeld(bool held);
+    void initInputMonitor();
+    void scanInputDevices();
+    void onInputEvent(int fd);
+
+    bool m_metaKeyHeld = false;
+    QTimer *m_rescanTimer = nullptr;
+    QList<QSocketNotifier *> m_inputNotifiers;
+    QList<int> m_inputFds;
 };


### PR DESCRIPTION
<img width="880" height="197" alt="屏幕截图_20260621_003847" src="https://github.com/user-attachments/assets/f167e573-732c-4d9b-8771-142254d84989" />

-   Monitor Meta key via /dev/input directly (no focus dependency)
-   Temporarily reveal hidden dock and display numbered badges on task icons while Meta is held
-   Add showOnMetaKey / showTaskNumbersOnMeta config options