### PR TITLE
ui: allow vertical offset adjustment for bottom-docked panel

### DIFF
--- a/package/contents/ui/Badge.qml
+++ b/package/contents/ui/Badge.qml
@@ -1,8 +1,8 @@
 /*
-    SPDX-FileCopyrightText: 2018 Kai Uwe Broulik <kde@privat.broulik.de>
-
-    SPDX-License-Identifier: GPL-2.0-or-later
-*/
+ *   SPDX-FileCopyrightText: 2018 Kai Uwe Broulik <kde@privat.broulik.de>
+ *
+ *   SPDX-License-Identifier: GPL-2.0-or-later
+ */
 
 pragma ComponentBehavior: Bound
 
@@ -23,22 +23,29 @@ Rectangle {
 
     property real renderScale: 1.8
 
-    implicitWidth: Math.max(height, Math.round(label.contentWidth + radius / 2)) // Add some padding around.
+    implicitWidth: Math.max(height, Math.round(label.contentWidth + radius / 2)) // Add some padding around.[cite: 2]
     implicitHeight: implicitWidth
 
     radius: height / 2
 
-    color: Kirigami.Theme.backgroundColor
+    color: Kirigami.Theme.backgroundColor //[cite: 2]
 
     antialiasing: true
+
+    // --- CUSTOM TRANSLATION ---
+    // Shifts the badge slightly further up and to the right relative to its parent anchors.
+    transform: Translate {
+        x: 6   // Positive value pushes rightwards
+        y: -6  // Negative value pushes upwards
+    }
 
     // Colored background
     Rectangle {
         anchors.fill: parent
         radius: height / 2
 
-        color: Qt.alpha(Kirigami.Theme.highlightColor, 0.3)
-        border.color: Kirigami.Theme.highlightColor
+        color: Qt.alpha(Kirigami.Theme.highlightColor, 0.3) //[cite: 2]
+        border.color: Kirigami.Theme.highlightColor //[cite: 2]
         border.width: 1
         antialiasing: true
     }
@@ -53,30 +60,30 @@ Rectangle {
         verticalAlignment: Text.AlignVCenter
 
         // Render grande para mantener nitidez
-        font.pixelSize: Math.round(parent.height * 0.55 * badgeRect.renderScale)
+        font.pixelSize: Math.round(parent.height * 0.55 * badgeRect.renderScale) //[cite: 2]
 
         // Reducimos visualmente
-        scale: 1 / badgeRect.renderScale
+        scale: 1 / badgeRect.renderScale //[cite: 2]
         transformOrigin: Item.Center
 
-        renderType: Text.NativeRendering
-        renderTypeQuality: Text.HighRenderTypeQuality
+        renderType: Text.NativeRendering //[cite: 2]
+        renderTypeQuality: Text.HighRenderTypeQuality //[cite: 2]
 
-        font.hintingPreference: Font.PreferFullHinting
+        font.hintingPreference: Font.PreferFullHinting //[cite: 2]
 
         layer.enabled: true
         smooth: true
 
         text: {
-            if (badgeRect.number < 0) {
-                return i18nc("Invalid number of new messages, overlay, keep short", "—");
-            } else if (badgeRect.number > 9999) {
-                return i18nc("Over 9999 new messages, overlay, keep short", "9,999+");
+            if (badgeRect.number < 0) { //[cite: 2]
+                return i18nc("Invalid number of new messages, overlay, keep short", "—"); //[cite: 2]
+            } else if (badgeRect.number > 9999) { //[cite: 2]
+                return i18nc("Over 9999 new messages, overlay, keep short", "9,999+"); //[cite: 2]
             } else {
-                return badgeRect.number.toLocaleString(Qt.locale(), 'f', 0);
+                return badgeRect.number.toLocaleString(Qt.locale(), 'f', 0); //[cite: 2]
             }
         }
 
-        textFormat: Text.PlainText
+        textFormat: Text.PlainText //[cite: 2]
     }
 }

--- a/package/contents/ui/Badge.qml
+++ b/package/contents/ui/Badge.qml
@@ -23,29 +23,22 @@ Rectangle {
 
     property real renderScale: 1.8
 
-    implicitWidth: Math.max(height, Math.round(label.contentWidth + radius / 2)) // Add some padding around.[cite: 2]
+    implicitWidth: Math.max(height > 0 ? height : 24, Math.round(label.contentWidth + radius / 2)) // Prevent 0/negative height initialization loops
     implicitHeight: implicitWidth
 
     radius: height / 2
 
-    color: Kirigami.Theme.backgroundColor //[cite: 2]
+    color: Kirigami.Theme.backgroundColor
 
     antialiasing: true
-
-    // --- CUSTOM TRANSLATION ---
-    // Shifts the badge slightly further up and to the right relative to its parent anchors.
-    transform: Translate {
-        x: 6   // Positive value pushes rightwards
-        y: -6  // Negative value pushes upwards
-    }
 
     // Colored background
     Rectangle {
         anchors.fill: parent
-        radius: height / 2
+        radius: parent.height / 2
 
-        color: Qt.alpha(Kirigami.Theme.highlightColor, 0.3) //[cite: 2]
-        border.color: Kirigami.Theme.highlightColor //[cite: 2]
+        color: Qt.alpha(Kirigami.Theme.highlightColor, 0.3)
+        border.color: Kirigami.Theme.highlightColor
         border.width: 1
         antialiasing: true
     }
@@ -60,30 +53,30 @@ Rectangle {
         verticalAlignment: Text.AlignVCenter
 
         // Render grande para mantener nitidez
-        font.pixelSize: Math.round(parent.height * 0.55 * badgeRect.renderScale) //[cite: 2]
+        font.pixelSize: Math.round(parent.height * 0.55 * badgeRect.renderScale)
 
         // Reducimos visualmente
-        scale: 1 / badgeRect.renderScale //[cite: 2]
+        scale: 1 / badgeRect.renderScale
         transformOrigin: Item.Center
 
-        renderType: Text.NativeRendering //[cite: 2]
-        renderTypeQuality: Text.HighRenderTypeQuality //[cite: 2]
+        renderType: Text.NativeRendering
+        renderTypeQuality: Text.HighRenderTypeQuality
 
-        font.hintingPreference: Font.PreferFullHinting //[cite: 2]
+        font.hintingPreference: Font.PreferFullHinting
 
         layer.enabled: true
         smooth: true
 
         text: {
-            if (badgeRect.number < 0) { //[cite: 2]
-                return i18nc("Invalid number of new messages, overlay, keep short", "—"); //[cite: 2]
-            } else if (badgeRect.number > 9999) { //[cite: 2]
-                return i18nc("Over 9999 new messages, overlay, keep short", "9,999+"); //[cite: 2]
+            if (badgeRect.number < 0) {
+                return i18nc("Invalid number of new messages, overlay, keep short", "—");
+            } else if (badgeRect.number > 9999) {
+                return i18nc("Over 9999 new messages, overlay, keep short", "9,999+");
             } else {
-                return badgeRect.number.toLocaleString(Qt.locale(), 'f', 0); //[cite: 2]
+                return badgeRect.number.toLocaleString(Qt.locale(), 'f', 0);
             }
         }
 
-        textFormat: Text.PlainText //[cite: 2]
+        textFormat: Text.PlainText
     }
 }

--- a/package/contents/ui/Task.qml
+++ b/package/contents/ui/Task.qml
@@ -26,31 +26,19 @@ PlasmaCore.ToolTipArea {
 
     activeFocusOnTab: true
 
-    // To achieve a bottom-to-top layout on vertical panels, the task manager
-    // is rotated by 180 degrees(see main.qml). This makes the tasks rotated,
-    // so un-rotate them here to fix that.
     rotation: Plasmoid.configuration.reverseMode && Plasmoid.formFactor === PlasmaCore.Types.Vertical ? 180 : 0
 
-    implicitHeight: inPopup
-    ? LayoutMetrics.preferredHeightInPopup()
-    : (tasksRoot.vertical
-    ? LayoutMetrics.preferredMinHeight()
-    : Math.max(tasksRoot.height / Plasmoid.configuration.maxStripes,
-               LayoutMetrics.preferredMinHeight()))
-    implicitWidth: tasksRoot.vertical
-    ? Math.max(LayoutMetrics.preferredMinWidth(), Math.min(LayoutMetrics.preferredMaxWidth(), tasksRoot.width / Plasmoid.configuration.maxStripes))
-    : 0
+    implicitHeight: inPopup ? LayoutMetrics.preferredHeightInPopup() : (tasksRoot.vertical ? LayoutMetrics.preferredMinHeight() : Math.max(tasksRoot.height / Plasmoid.configuration.maxStripes, LayoutMetrics.preferredMinHeight()))
+    implicitWidth: tasksRoot.vertical ? Math.max(LayoutMetrics.preferredMinWidth(), Math.min(LayoutMetrics.preferredMaxWidth(), tasksRoot.width / Plasmoid.configuration.maxStripes)) : 0
 
     Layout.fillWidth: true
     Layout.fillHeight: !inPopup
-    Layout.maximumWidth: tasksRoot.vertical
-    ? -1
-    : ((model.IsLauncher && !tasksRoot.iconsOnly) ? tasksRoot.height / taskList.rows : LayoutMetrics.preferredMaxWidth())
+    Layout.maximumWidth: tasksRoot.vertical ? -1 : ((model.IsLauncher && !tasksRoot.iconsOnly) ? tasksRoot.height / taskList.rows : LayoutMetrics.preferredMaxWidth())
     Layout.maximumHeight: tasksRoot.vertical ? LayoutMetrics.preferredMaxHeight() : -1
 
     required property var model
     required property int index
-    required property /*main.qml*/ Item tasksRoot
+    required property Item tasksRoot
 
     readonly property int pid: model.AppPid
     readonly property string appName: model.AppName
@@ -76,124 +64,54 @@ PlasmaCore.ToolTipArea {
     readonly property bool playingAudio: hasAudioStream && audioStreams.some(item => !item.corked)
     readonly property bool muted: hasAudioStream && audioStreams.every(item => item.muted)
 
-    readonly property bool highlighted: (inPopup && activeFocus) || (!inPopup && containsMouse)
-    || (task.contextMenu && task.contextMenu.status === PlasmaExtras.Menu.Open)
-    || (!!tasksRoot.groupDialog && tasksRoot.groupDialog.visualParent === task)
+    readonly property bool highlighted: (inPopup && activeFocus) || (!inPopup && containsMouse) || (task.contextMenu && task.contextMenu.status === PlasmaExtras.Menu.Open) || (!!tasksRoot.groupDialog && tasksRoot.groupDialog.visualParent === task)
 
     active: !inPopup && !tasksRoot.groupDialog && task.contextMenu?.status !== PlasmaExtras.Menu.Open
     interactive: model.IsWindow || mainItem.playerData
     location: Plasmoid.location
     mainItem: !Plasmoid.configuration.showToolTips || !model.IsWindow ? pinnedAppToolTipDelegate : openWindowToolTipDelegate
 
-    // y hace que el panel se expanda elásticamente.
     width: Plasmoid.configuration.iconSize
     height: tasksRoot.height
-
-    // Desactivamos el recorte para que el zoom y el reflejo "vuelen" fuera
     clip: false
 
-    // Esta propiedad la activamos desde el MouseArea del main.qml
     property bool isHovered: false
-
-    property Item dockRef: null // Esto recibirá el 'dockMouseArea' de main.qml
+    property Item dockRef: null
 
     readonly property real _baseSize: Plasmoid.configuration.iconSize
     readonly property real _sigma: _baseSize * Plasmoid.configuration.amplitud
     readonly property real _zoom: (Plasmoid.configuration.magnification || 0) / 100
 
-    // ---------------------------------------------------------
-    // INICIO DEL CÓDIGO ZOOM (OSX EFFECT)
-    // ---------------------------------------------------------
-
     property real zoomFactor: {
-
         if (!dockRef || _zoom <= 0) return 1.0;
-
         let mousePos = dockRef.smoothMouse;
-
         if (mousePos < 0) return 1.0;
 
-        // Tamaño total SIN zoom
         let totalSize = tasksRoot.taskRepeater.count * _baseSize;
-
-        // Área disponible según orientación
-        let availableSize = tasks.vertical
-        ? tasksRoot.taskList.height
-        : tasksRoot.taskList.width;
-
-        // Offset centrado
+        let availableSize = tasksRoot.vertical ? tasksRoot.taskList.height : tasksRoot.taskList.width;
         let centerOffset = (availableSize - totalSize) / 2;
-
-        // Centro del icono actual
         let iconCenter = centerOffset + (index * _baseSize) + (_baseSize / 2);
-
-        // Distancia mouse-icono
         let distance = Math.abs(mousePos - iconCenter);
 
-        // Corte para rendimiento
         if (distance > _sigma * 3) return 1.0;
-
-        // Entrada/salida animada
         let dynamicZoom = _zoom * entryProgress;
-
-        // Curva gaussiana tipo macOS
         return 1.0 + dynamicZoom * Math.exp(-(Math.pow(distance, 2) / (2 * Math.pow(_sigma, 2))));
     }
 
     property real entryProgress: (dockRef && dockRef.insideDock) ? 1.0 : 0.0
 
     Behavior on entryProgress {
-        NumberAnimation {
-            duration: 200
-            easing.type: Easing.OutCubic
-        }
+        NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
     }
 
     Accessible.name: model.display
-    Accessible.description: {
-        if (!model.display) {
-            return "";
-        }
-
-        if (model.IsLauncher) {
-            return i18nc("@info:usagetip %1 application name", "Launch %1", model.display)
-        }
-
-        let smartLauncherDescription = "";
-        if (iconBox.active) {
-            smartLauncherDescription += i18ncp("@info:tooltip", "There is %1 new message.", "There are %1 new messages.", task.smartLauncherItem.count);
-        }
-
-        if (model.IsGroupParent) {
-            switch (Plasmoid.configuration.groupedTaskVisualization) {
-                case 0:
-                    break; // Use the default description
-                case 1: {
-                    return `${i18nc("@info:usagetip %1 task name", "Show Task tooltip for %1", model.display)}; ${smartLauncherDescription}`;
-                }
-                case 2: {
-                    if (effectWatcher.registered) {
-                        return `${i18nc("@info:usagetip %1 task name", "Show windows side by side for %1", model.display)}; ${smartLauncherDescription}`;
-                    }
-                    // fallthrough
-                }
-                default:
-                    return `${i18nc("@info:usagetip %1 task name", "Open textual list of windows for %1", model.display)}; ${smartLauncherDescription}`;
-            }
-        }
-
-        return `${i18nc("@info:usagetip %1 task name", "Activate %1", model.display)}; ${smartLauncherDescription}`;
-    }
     Accessible.role: Accessible.Button
     Accessible.onPressAction: leftTapHandler.leftClick()
 
     onToolTipVisibleChanged: toolTipVisible => {
         task.toolTipOpen = toolTipVisible;
-        if (!toolTipVisible) {
-            tasksRoot.toolTipOpenedByClick = null;
-        } else {
-            tasksRoot.toolTipAreaItem = task;
-        }
+        if (!toolTipVisible) tasksRoot.toolTipOpenedByClick = null;
+        else tasksRoot.toolTipAreaItem = task;
     }
 
     onContainsMouseChanged: {
@@ -205,36 +123,29 @@ PlasmaCore.ToolTipArea {
         }
     }
 
-    onHighlightedChanged: {
-        // ensure it doesn't get stuck with a window highlighted
-        tasksRoot.cancelHighlightWindows();
-    }
-
+    onHighlightedChanged: { tasksRoot.cancelHighlightWindows(); }
     onPidChanged: updateAudioStreams({delay: false})
     onAppNameChanged: updateAudioStreams({delay: false})
 
     onIsWindowChanged: {
         if (model.IsWindow) {
-            taskInitComponent.createObject(task);
+            tasksRoot.taskInitComponent.createObject(task);
             updateAudioStreams({delay: false});
         }
     }
 
     onChildCountChanged: {
         if (TaskTools.taskManagerInstanceCount < 2 && childCount > previousChildCount) {
-            tasksModel.requestPublishDelegateGeometry(modelIndex(), backend.globalRect(task), task);
+            tasksRoot.tasksModel.requestPublishDelegateGeometry(modelIndex(), tasksRoot.backend.globalRect(task), task);
         }
-
         previousChildCount = childCount;
     }
 
     onIndexChanged: {
         hideToolTip();
-
-        if (!inPopup && !tasksRoot.vertical
-            && !Plasmoid.configuration.separateLaunchers) {
+        if (!inPopup && !tasksRoot.vertical && !Plasmoid.configuration.separateLaunchers) {
             tasksRoot.requestLayout();
-            }
+        }
     }
 
     onSmartLauncherEnabledChanged: {
@@ -242,9 +153,7 @@ PlasmaCore.ToolTipArea {
             const component = Qt.createComponent("org.vicko.wavetask", "SmartLauncherItem");
             const smartLauncher = component.createObject(task);
             component.destroy();
-
             smartLauncher.launcherUrl = Qt.binding(() => model.LauncherUrlWithoutIcon);
-
             smartLauncherItem = smartLauncher;
         }
     }
@@ -258,8 +167,6 @@ PlasmaCore.ToolTipArea {
             }
             return;
         }
-        // Create item on demand instead of using Loader to reduce memory consumption,
-        // because only a few applications have audio streams.
         const component = Qt.createComponent("AudioStream.qml");
         audioStreamIcon = component.createObject(task);
         component.destroy();
@@ -268,93 +175,49 @@ PlasmaCore.ToolTipArea {
 
     Keys.onMenuPressed: event => contextMenuTimer.start()
     Keys.onReturnPressed: event => TaskTools.activateTask(modelIndex(), model, event.modifiers, task, Plasmoid, tasksRoot, effectWatcher.registered)
-    Keys.onEnterPressed: event => Keys.returnPressed(event);
-    Keys.onSpacePressed: event => Keys.returnPressed(event);
+    Keys.onEnterPressed: event => Keys.returnPressed(event)
+    Keys.onSpacePressed: event => Keys.returnPressed(event)
     Keys.onUpPressed: event => Keys.leftPressed(event)
     Keys.onDownPressed: event => Keys.rightPressed(event)
-    Keys.onLeftPressed: event => {
-        if (!inPopup && (event.modifiers & Qt.ControlModifier) && (event.modifiers & Qt.ShiftModifier)) {
-            tasksModel.move(task.index, task.index - 1);
-        } else {
-            event.accepted = false;
-        }
-    }
-    Keys.onRightPressed: event => {
-        if (!inPopup && (event.modifiers & Qt.ControlModifier) && (event.modifiers & Qt.ShiftModifier)) {
-            tasksModel.move(task.index, task.index + 1);
-        } else {
-            event.accepted = false;
-        }
-    }
 
-    function modelIndex(): /*QModelIndex*/ var {
-        return inPopup
-        ? tasksModel.makeModelIndex(groupDialog.visualParent.index, index)
-        : tasksModel.makeModelIndex(index);
+    function modelIndex(): var {
+        return inPopup ? tasksRoot.tasksModel.makeModelIndex(groupDialog.visualParent.index, index) : tasksRoot.tasksModel.makeModelIndex(index);
     }
 
     function showContextMenu(args: var): void {
         task.hideImmediately();
-        contextMenu = tasksRoot.createContextMenu(task, modelIndex(), args) as ContextMenu;
+        contextMenu = tasksRoot.createContextMenu(task, modelIndex(), args);
         contextMenu.show();
     }
 
     function updateAudioStreams(args: var): void {
-        if (args) {
-            // When the task just appeared (e.g. virtual desktop switch), show the audio indicator
-            // right away. Only when audio streams change during the lifetime of this task, delay
-            // showing that to avoid distraction.
-            delayAudioStreamIndicator = !!args.delay;
-        }
-
-        var pa = pulseAudio.item;
+        if (args) delayAudioStreamIndicator = !!args.delay;
+        var pa = tasksRoot.pulseAudio.item;
         if (!pa || !task.isWindow) {
             task.audioStreams = [];
             return;
         }
-
-        // Check appid first for app using portal
-        // https://docs.pipewire.org/page_portal.html
         var streams = pa.streamsForAppId(task.appId);
         if (!streams.length) {
             streams = pa.streamsForPid(model.AppPid);
-            if (streams.length) {
-                pa.registerPidMatch(model.AppName);
-            } else {
-                // We only want to fall back to appName matching if we never managed to map
-                // a PID to an audio stream window. Otherwise if you have two instances of
-                // an application, one playing and the other not, it will look up appName
-                // for the non-playing instance and erroneously show an indicator on both.
-                if (!pa.hasPidMatch(model.AppName)) {
-                    streams = pa.streamsForAppName(model.AppName);
-                }
-            }
+            if (streams.length) pa.registerPidMatch(model.AppName);
+            else if (!pa.hasPidMatch(model.AppName)) streams = pa.streamsForAppName(model.AppName);
         }
-
         task.audioStreams = streams;
     }
 
     function toggleMuted(): void {
-        if (muted) {
-            task.audioStreams.forEach(item => item.unmute());
-        } else {
-            task.audioStreams.forEach(item => item.mute());
-        }
+        if (muted) task.audioStreams.forEach(item => item.unmute());
+        else task.audioStreams.forEach(item => item.mute());
     }
 
-    // Will also be called in activateTaskAtIndex(index)
     function updateMainItemBindings(): void {
-        if ((mainItem.parentTask === this && mainItem.rootIndex.row === index)
-            || (tasksRoot.toolTipOpenedByClick === null && !active)
-            || (tasksRoot.toolTipOpenedByClick !== null && tasksRoot.toolTipOpenedByClick !== this)) {
+        if ((mainItem.parentTask === this && mainItem.rootIndex.row === index) || (tasksRoot.toolTipOpenedByClick === null && !active) || (tasksRoot.toolTipOpenedByClick !== null && tasksRoot.toolTipOpenedByClick !== this)) {
             return;
-            }
-
-            mainItem.blockingUpdates = (mainItem.isGroup !== model.IsGroupParent); // BUG 464597 Force unload the previous component
-
-            mainItem.parentTask = this;
-        mainItem.rootIndex = tasksModel.makeModelIndex(index, -1);
-
+        }
+        mainItem.blockingUpdates = (mainItem.isGroup !== model.IsGroupParent);
+        mainItem.parentTask = this;
+        mainItem.rootIndex = tasksRoot.tasksModel.makeModelIndex(index, -1);
         mainItem.appName = Qt.binding(() => model.AppName);
         mainItem.pidParent = Qt.binding(() => model.AppPid);
         mainItem.windows = Qt.binding(() => model.WinIdList);
@@ -368,189 +231,77 @@ PlasmaCore.ToolTipArea {
         mainItem.virtualDesktops = Qt.binding(() => model.VirtualDesktops);
         mainItem.isOnAllVirtualDesktops = Qt.binding(() => model.IsOnAllVirtualDesktops);
         mainItem.activities = Qt.binding(() => model.Activities);
-
         mainItem.smartLauncherCountVisible = Qt.binding(() => smartLauncherItem?.countVisible ?? false);
         mainItem.smartLauncherCount = Qt.binding(() => mainItem.smartLauncherCountVisible ? (smartLauncherItem?.count ?? 0) : 0);
-
         mainItem.blockingUpdates = false;
         tasksRoot.toolTipAreaItem = this;
     }
 
-    Connections {
-        target: pulseAudio.item
-        ignoreUnknownSignals: true // Plasma-PA might not be available
-        function onStreamsChanged(): void {
-            task.updateAudioStreams({delay: true})
-        }
-    }
-
-    TapHandler {
-        id: menuTapHandler
-        acceptedButtons: Qt.LeftButton
-        acceptedDevices: PointerDevice.TouchScreen | PointerDevice.Stylus
-        gesturePolicy: TapHandler.ReleaseWithinBounds
-        onLongPressed: {
-            // When we're a launcher, there's no window controls, so we can show all
-            // places without the menu getting super huge.
-            if (task.model.IsLauncher) {
-                task.showContextMenu({showAllPlaces: true})
-            } else {
-                task.showContextMenu();
-            }
-        }
-    }
-
-    TapHandler {
-        acceptedButtons: Qt.RightButton
-        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.Stylus
-        gesturePolicy: TapHandler.WithinBounds // Release grab when menu appears
-        onPressedChanged: if (pressed) contextMenuTimer.start()
-    }
-
-    Timer {
-        id: contextMenuTimer
-        interval: 0
-        onTriggered: menuTapHandler.longPressed()
-    }
-
-    TapHandler {
-        id: leftTapHandler
-        acceptedButtons: Qt.LeftButton
-        onTapped: (eventPoint, button) => leftClick()
-
-        function leftClick(): void {
-            if (task.active) {
-                task.hideToolTip();
-            }
-            TaskTools.activateTask(modelIndex(), model, point.modifiers, task, Plasmoid, tasksRoot, effectWatcher.registered);
-        }
-    }
-
-    TapHandler {
-        acceptedButtons: Qt.MiddleButton | Qt.BackButton | Qt.ForwardButton
-        onTapped: (eventPoint, button) => {
-            if (button === Qt.MiddleButton) {
-                if (Plasmoid.configuration.middleClickAction === TaskManagerApplet.Backend.NewInstance) {
-                    tasksModel.requestNewInstance(modelIndex());
-                } else if (Plasmoid.configuration.middleClickAction === TaskManagerApplet.Backend.Close) {
-                    tasksModel.requestClose(modelIndex());
-                } else if (Plasmoid.configuration.middleClickAction === TaskManagerApplet.Backend.ToggleMinimized) {
-                    tasksModel.requestToggleMinimized(modelIndex());
-                } else if (Plasmoid.configuration.middleClickAction === TaskManagerApplet.Backend.ToggleGrouping) {
-                    tasksModel.requestToggleGrouping(modelIndex());
-                } else if (Plasmoid.configuration.middleClickAction === TaskManagerApplet.Backend.BringToCurrentDesktop) {
-                    tasksModel.requestVirtualDesktops(modelIndex(), [virtualDesktopInfo.currentDesktop]);
-                }
-            } else if (button === Qt.BackButton || button === Qt.ForwardButton) {
-                const playerData = mpris2Source.playerForLauncherUrl(task.model.LauncherUrlWithoutIcon, task.model.AppPid);
-                if (playerData) {
-                    if (button === Qt.BackButton) {
-                        playerData.Previous();
-                    } else {
-                        playerData.Next();
-                    }
-                } else {
-                    eventPoint.accepted = false;
-                }
-            }
-
-            task.tasksRoot.cancelHighlightWindows();
-        }
-    }
-
     KSvg.FrameSvgItem {
         id: frame
-
-          anchors {
+        anchors {
             fill: parent
-
             topMargin: {
-                if (!task.tasksRoot.vertical && taskList.rows > 1) {
-                    return LayoutMetrics.iconMargin
-                }
-
-                let iconAlign = Math.round(parent.height - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing
-                let indicatorOffset = -Kirigami.Units.gridUnit / tasks.skinParams.positionTaskIndicator
-
-                return tasksRoot.isTopPanel ? indicatorOffset : iconAlign
+                if (!task.tasksRoot.vertical && tasksRoot.taskList.rows > 1) return LayoutMetrics.iconMargin;
+                let iconAlign = Math.round(parent.height - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing;
+                let indicatorOffset = -Kirigami.Units.gridUnit / tasksRoot.skinParams.positionTaskIndicator;
+                return tasksRoot.isTopPanel ? indicatorOffset : iconAlign;
             }
             bottomMargin: {
-                if (!task.tasksRoot.vertical && taskList.rows > 1) {
-                    return LayoutMetrics.iconMargin
-                }
-
-                let iconAlign = Math.round(parent.height - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing
-                let indicatorOffset = -Kirigami.Units.gridUnit / tasks.skinParams.positionTaskIndicator
-
-                return tasksRoot.isTopPanel ? iconAlign : indicatorOffset
+                if (!task.tasksRoot.vertical && tasksRoot.taskList.rows > 1) return LayoutMetrics.iconMargin;
+                let iconAlign = Math.round(parent.height - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing;
+                let indicatorOffset = -Kirigami.Units.gridUnit / tasksRoot.skinParams.positionTaskIndicator;
+                return tasksRoot.isTopPanel ? iconAlign : indicatorOffset;
             }
             leftMargin: {
-                if ((inPopup || tasksRoot.vertical) && taskList.columns > 1) {
-                    return LayoutMetrics.iconMargin
-                }
-
-                let iconAlign = Math.round(parent.width - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing * 0.5
-                let indicatorOffset = -Kirigami.Units.gridUnit / tasks.skinParams.positionTaskIndicator
-
-                return tasksRoot.isLeftPanel ? indicatorOffset : iconAlign
+                if ((inPopup || tasksRoot.vertical) && tasksRoot.taskList.columns > 1) return LayoutMetrics.iconMargin;
+                let iconAlign = Math.round(parent.width - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing * 0.5;
+                let indicatorOffset = -Kirigami.Units.gridUnit / tasksRoot.skinParams.positionTaskIndicator;
+                return tasksRoot.isLeftPanel ? indicatorOffset : iconAlign;
             }
             rightMargin: {
-                if (!task.tasksRoot.vertical && taskList.rows > 1) {
-                    return LayoutMetrics.iconMargin
-                }
-
-                let iconAlign = Math.round(parent.width - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing * 0.5
-                let indicatorOffset = -Kirigami.Units.gridUnit / tasks.skinParams.positionTaskIndicator
-
-                return tasksRoot.isLeftPanel ? iconAlign : indicatorOffset
+                if (!task.tasksRoot.vertical && tasksRoot.taskList.rows > 1) return LayoutMetrics.iconMargin;
+                let iconAlign = Math.round(parent.width - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing * 0.5;
+                let indicatorOffset = -Kirigami.Units.gridUnit / tasksRoot.skinParams.positionTaskIndicator;
+                return tasksRoot.isLeftPanel ? iconAlign : indicatorOffset;
             }
         }
 
-        imagePath: (Plasmoid.configuration.skinName === "Default Plasma") ? "widgets/tasks" : tasks.skinParams.imagetask
+        imagePath: (Plasmoid.configuration.skinName === "Default Plasma") ? "widgets/tasks" : tasksRoot.skinParams.imagetask
         property bool isHovered: task.highlighted && Plasmoid.configuration.taskHoverEffect
         property string basePrefix: "normal"
         prefix: isHovered ? TaskTools.taskPrefixHovered(basePrefix, Plasmoid.location) : TaskTools.taskPrefix(basePrefix, Plasmoid.location)
 
-
-        // Avoid repositioning delegate item after dragFinished
         DragHandler {
             id: dragHandler
             grabPermissions: PointerHandler.CanTakeOverFromHandlersOfDifferentType
-
             function setRequestedInhibitDnd(value: bool): void {
-                // This is modifying the value in the panel containment that
-                // inhibits accepting drag and drop, so that we don't accidentally
-                // drop the task on this panel.
                 let item = this;
                 while (item.parent) {
                     item = item.parent;
                     if (item.appletRequestsInhibitDnD !== undefined) {
-                        item.appletRequestsInhibitDnD = value
+                        item.appletRequestsInhibitDnD = value;
                     }
                 }
             }
-
             onActiveChanged: {
                 if (active) {
                     icon.grabToImage(result => {
-                        if (!dragHandler.active) {
-                            // BUG 466675 grabToImage is async, so avoid updating dragSource when active is false
-                            return;
-                        }
+                        if (!dragHandler.active) return;
                         setRequestedInhibitDnd(true);
                         tasksRoot.dragSource = task;
-                        dragHelper.Drag.imageSource = result.url;
-                        dragHelper.Drag.mimeData = {
-                            "text/x-orgkdeplasmataskmanager_taskurl": backend.tryDecodeApplicationsUrl(model.LauncherUrlWithoutIcon).toString(),
+                        tasksRoot.dragHelper.Drag.imageSource = result.url;
+                        tasksRoot.dragHelper.Drag.mimeData = {
+                            "text/x-orgkdeplasmataskmanager_taskurl": tasksRoot.backend.tryDecodeApplicationsUrl(model.LauncherUrlWithoutIcon).toString(),
                                      [model.MimeType]: model.MimeData,
                                      "application/x-orgkdeplasmataskmanager_taskbuttonitem": model.MimeData,
                         };
-                        dragHelper.Drag.active = dragHandler.active;
+                        tasksRoot.dragHelper.Drag.active = dragHandler.active;
                     });
                 } else {
                     setRequestedInhibitDnd(false);
-                    dragHelper.Drag.active = false;
-                    dragHelper.Drag.imageSource = "";
+                    tasksRoot.dragHelper.Drag.active = false;
+                    tasksRoot.dragHelper.Drag.imageSource = "";
                 }
             }
         }
@@ -558,360 +309,155 @@ PlasmaCore.ToolTipArea {
 
     Loader {
         id: taskProgressOverlayLoader
-
         anchors.fill: frame
         asynchronous: true
         active: task.smartLauncherItem && task.smartLauncherItem.progressVisible
-
         source: "TaskProgressOverlay.qml"
     }
 
-        Loader {
-            id: iconBox
+    Loader {
+        id: iconBox
+        width: Plasmoid.configuration.iconSize
+        height: Plasmoid.configuration.iconSize
+        anchors.centerIn: tasksRoot.vertical ? parent : undefined
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: ((!tasksRoot.vertical) && Plasmoid.location === PlasmaCore.Types.BottomEdge) ? 0 : Math.round((tasksRoot.height / 2) - (Kirigami.Units.iconSizes.small * 0.14))
+        anchors.horizontalCenter: (!tasksRoot.vertical) ? parent.horizontalCenter : undefined
 
-            // Mantenemos el contenedor con un tamaño fijo
-            width: Plasmoid.configuration.iconSize
-            height: Plasmoid.configuration.iconSize
+        property int baseRenderSize: Plasmoid.configuration.iconSize * 2
+        property Item visualIcon: icon // Expose to sub-loaded contexts safely
 
-           anchors.centerIn: tasksRoot.vertical
-           ? parent
-           : undefined
-
-           anchors.bottom: ((!tasksRoot.vertical) && Plasmoid.location === PlasmaCore.Types.BottomEdge)
-           ? parent.bottom
-           : parent.bottom
-
-           anchors.bottomMargin: ((!tasksRoot.vertical) && Plasmoid.location === PlasmaCore.Types.BottomEdge)
-           ? 0
-           : Math.round((tasksRoot.height / 2) - (Kirigami.Units.iconSizes.small * 0.14))
-
-
-           anchors.horizontalCenter: (!tasksRoot.vertical)
-           ? parent.horizontalCenter
-           : undefined
-
-            property int baseRenderSize: Plasmoid.configuration.iconSize * 2
-
-            SequentialAnimation {
-                id: bounceAnimation
-                running: task.model.IsStartup || task.model.IsDemandingAttention || (task.smartLauncherItem && task.smartLauncherItem.urgent)
-                loops: Animation.Infinite
-                alwaysRunToEnd: true
-
-                // Calculamos la altura del salto considerando el factor de escala (zoom)
-                property real jumpHeight: {
-                    let currentSize = Plasmoid.configuration.iconSize * zoomFactor;
-                    let idealJump = currentSize * 0.6; // Salto base: 60% del tamaño del icono
-
-                    // Calculamos el espacio disponible para evitar que el icono se corte con el borde del panel
-                    let headroom = Math.max(0, tasksRoot.height - Plasmoid.configuration.iconSize);
-
-                    // Limitamos el salto al espacio real disponible
-                    return Math.min(idealJump, headroom);
-                }
-
-                // Animación de ascenso (impulso)
-                NumberAnimation {
-                    target: iconBox
-                    property: "anchors.bottomMargin"
-                    from: 0
-                    to: bounceAnimation.jumpHeight
-                    duration: 300
-                    easing.type: Easing.OutQuad
-                }
-
-                // Animación de descenso (gravedad)
-                NumberAnimation {
-                    target: iconBox
-                    property: "anchors.bottomMargin"
-                    to: 0
-                    duration: 300
-                    easing.type: Easing.InQuad
-                }
+        SequentialAnimation {
+            id: bounceAnimation
+            running: task.model.IsStartup || task.model.IsDemandingAttention || (task.smartLauncherItem && task.smartLauncherItem.urgent)
+            loops: Animation.Infinite
+            alwaysRunToEnd: true
+            property real jumpHeight: {
+                let currentSize = Plasmoid.configuration.iconSize * zoomFactor;
+                let idealJump = currentSize * 0.6;
+                let headroom = Math.max(0, tasksRoot.height - Plasmoid.configuration.iconSize);
+                return Math.min(idealJump, headroom);
             }
+            NumberAnimation { target: iconBox; property: "anchors.bottomMargin"; from: 0; to: bounceAnimation.jumpHeight; duration: 300; easing.type: Easing.OutQuad }
+            NumberAnimation { target: iconBox; property: "anchors.bottomMargin"; to: 0; duration: 300; easing.type: Easing.InQuad }
+        }
 
-            // El zoom se aplica solo como transformación visual al contenedor completo
-            scale: zoomFactor
-            transformOrigin: {
-                switch (Plasmoid.location) {
-                    case PlasmaCore.Types.BottomEdge:
-                        return Item.Bottom;
-
-                    case PlasmaCore.Types.TopEdge:
-                        return Item.Top;
-
-                    case PlasmaCore.Types.LeftEdge:
-                        return Item.Left;
-                    case PlasmaCore.Types.RightEdge:
-                        return Item.Right;
-
-                    default:
-                        return Item.Bottom;
-                }
-            }
-
-            asynchronous: true
-            active: task.smartLauncherItem && task.smartLauncherItem.countVisible
-            source: "TaskBadgeOverlay.qml"
-
-            function adjustMargin(isVertical: bool, size: real, margin: real): real {
-                if (!size) {
-                    return margin;
-                }
-
-                var margins = isVertical ? LayoutMetrics.horizontalMargins() : LayoutMetrics.verticalMargins();
-
-                if ((size - margins) < Kirigami.Units.iconSizes.small) {
-                    return Math.ceil((margin * (Kirigami.Units.iconSizes.small / size)) / 2);
-                }
-
-                return margin;
-            }
-
-            Kirigami.Icon {
-                id: icon
-
-                width: iconBox.baseRenderSize
-                height: iconBox.baseRenderSize
-
-                source: model.decoration
-
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.bottom: parent.bottom
-                anchors.bottomMargin: tasksRoot.isTopPanel ? 0 : Kirigami.Units.smallSpacing
-                anchors.topMargin: tasksRoot.isTopPanel ? Kirigami.Units.smallSpacing : 0
-
-
-                transformOrigin: Item.Bottom
-
-                scale: 1 / (iconBox.baseRenderSize / iconBox.width)
-
-                smooth: true
-                antialiasing: true
-            }
-
-            Item {
-                id: reflectionContainer
-
-                visible: Plasmoid.configuration.showReflection
-                opacity: 0.4
-                clip: true
-                z: -5
-
-                width: tasksRoot.vertical
-                ? iconBox.width / 2
-                : iconBox.width
-
-                height: tasksRoot.vertical
-                ? iconBox.height
-                : iconBox.height / 2
-
-                x: {
-                    switch (Plasmoid.location) {
-
-                        case PlasmaCore.Types.LeftEdge:
-                            return -width - Kirigami.Units.smallSpacing * 2.5
-
-                        case PlasmaCore.Types.RightEdge:
-                            return iconBox.width + Kirigami.Units.smallSpacing * 2.5
-
-                        default:
-                            return 0
-                    }
-                }
-
-                y: {
-                    switch (Plasmoid.location) {
-
-                        case PlasmaCore.Types.TopEdge:
-                            return -height - Kirigami.Units.smallSpacing * 2
-
-                        case PlasmaCore.Types.BottomEdge:
-                            return iconBox.height + Kirigami.Units.smallSpacing * 2
-
-                        default:
-                            return 0
-                    }
-                }
-
-                Kirigami.Icon {
-                    id: reflectionIcon
-
-                    width: icon.width
-                    height: icon.height
-
-                    source: icon.source
-                    smooth: true
-                    antialiasing: true
-
-                    anchors.centerIn: parent
-
-                    scale: icon.scale
-
-                    transform: Scale {
-                        origin.x: reflectionIcon.width / 2
-                        origin.y: reflectionIcon.height / 2
-
-                        xScale: tasksRoot.vertical ? -1 : 1
-                        yScale: tasksRoot.vertical ? 1 : -1
-                    }
-                }
-            }
-
-            states: [
-                // Using a state transition avoids a binding loop between label.visible and
-                // the text label margin, which derives from the icon width.
-                State {
-                    name: "standalone"
-                    when: !label.visible && task.parent
-
-                    AnchorChanges {
-                        target: iconBox
-                        anchors.left: undefined
-                        anchors.horizontalCenter: parent.horizontalCenter
-                    }
-
-                    PropertyChanges {
-                        target: iconBox
-                        anchors.leftMargin: 0
-                        width: Math.min(task.parent.minimumWidth, tasks.height)
-                        - adjustMargin(true, task.width, taskFrame.margins.left)
-                        - adjustMargin(true, task.width, taskFrame.margins.right)
-                    }
-                }
-            ]
-
-            Loader {
-                anchors.centerIn: parent
-                width: Plasmoid.configuration.iconSize
-                height: Plasmoid.configuration.iconSize
-                active: model.IsStartup
-                sourceComponent: busyIndicator
+        scale: zoomFactor
+        transformOrigin: {
+            switch (Plasmoid.location) {
+                case PlasmaCore.Types.BottomEdge: return Item.Bottom;
+                case PlasmaCore.Types.TopEdge: return Item.Top;
+                case PlasmaCore.Types.LeftEdge: return Item.Left;
+                case PlasmaCore.Types.RightEdge: return Item.Right;
+                default: return Item.Bottom;
             }
         }
 
-    // --- META KEY TASK INDEX BADGE ---
+        asynchronous: true
+        active: task.smartLauncherItem && task.smartLauncherItem.countVisible
+        source: "TaskBadgeOverlay.qml"
+
+        function adjustMargin(isVertical: bool, size: real, margin: real): real {
+            if (!size) return margin;
+            var margins = isVertical ? LayoutMetrics.horizontalMargins() : LayoutMetrics.verticalMargins();
+            if ((size - margins) < Kirigami.Units.iconSizes.small) return Math.ceil((margin * (Kirigami.Units.iconSizes.small / size)) / 2);
+            return margin;
+        }
+
+        Kirigami.Icon {
+            id: icon
+            width: iconBox.baseRenderSize
+            height: iconBox.baseRenderSize
+            source: model.decoration
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: tasksRoot.isTopPanel ? 0 : Kirigami.Units.smallSpacing
+            anchors.topMargin: tasksRoot.isTopPanel ? Kirigami.Units.smallSpacing : 0
+            transformOrigin: Item.Bottom
+            scale: 1 / (iconBox.baseRenderSize / iconBox.width)
+            smooth: true; antialiasing: true
+        }
+
+        Item {
+            id: reflectionContainer
+            visible: Plasmoid.configuration.showReflection
+            opacity: 0.4; clip: true; z: -5
+            width: tasksRoot.vertical ? iconBox.width / 2 : iconBox.width
+            height: tasksRoot.vertical ? iconBox.height : iconBox.height / 2
+            x: {
+                switch (Plasmoid.location) {
+                    case PlasmaCore.Types.LeftEdge: return -width - Kirigami.Units.smallSpacing * 2.5;
+                    case PlasmaCore.Types.RightEdge: return iconBox.width + Kirigami.Units.smallSpacing * 2.5;
+                    default: return 0;
+                }
+            }
+            y: {
+                switch (Plasmoid.location) {
+                    case PlasmaCore.Types.TopEdge: return -height - Kirigami.Units.smallSpacing * 2;
+                    case PlasmaCore.Types.BottomEdge: return iconBox.height + Kirigami.Units.smallSpacing * 2;
+                    default: return 0;
+                }
+            }
+            Kirigami.Icon {
+                id: reflectionIcon
+                width: icon.width; height: icon.height
+                source: icon.source; smooth: true; antialiasing: true
+                anchors.centerIn: parent
+                scale: icon.scale
+                transform: Scale { origin.x: reflectionIcon.width / 2; origin.y: reflectionIcon.height / 2; xScale: tasksRoot.vertical ? -1 : 1; yScale: tasksRoot.vertical ? 1 : -1 }
+            }
+        }
+
+        states: [
+            State {
+                name: "standalone"
+                when: !label.visible && task.parent
+                AnchorChanges { target: iconBox; anchors.left: undefined; anchors.horizontalCenter: parent.horizontalCenter }
+                PropertyChanges { target: iconBox; anchors.leftMargin: 0; width: Math.min(task.parent.minimumWidth, tasksRoot.height) - adjustMargin(true, task.width, tasksRoot.taskFrame.margins.left) - adjustMargin(true, task.width, tasksRoot.taskFrame.margins.right) }
+            }
+        ]
+
+        Loader {
+            anchors.centerIn: parent
+            width: Plasmoid.configuration.iconSize; height: Plasmoid.configuration.iconSize
+            active: model.IsStartup
+            sourceComponent: busyIndicator
+        }
+    }
+
     Item {
         id: metaIndexBadge
-
         visible: tasksRoot.metaShowActive && Plasmoid.configuration.showTaskNumbersOnMeta
-
-        // Position depends on panel location:
-        // Bottom panel: above icon; Top panel: below icon
-        // Left panel: right of icon; Right panel: left of icon
         anchors.horizontalCenter: tasksRoot.vertical ? undefined : iconBox.horizontalCenter
         anchors.verticalCenter: tasksRoot.vertical ? iconBox.verticalCenter : undefined
-
-        anchors.bottom: tasksRoot.vertical ? undefined
-            : (tasksRoot.isTopPanel ? undefined : iconBox.top)
-        anchors.top: tasksRoot.vertical ? undefined
-            : (tasksRoot.isTopPanel ? iconBox.bottom : undefined)
-        anchors.left: tasksRoot.vertical
-            ? (tasksRoot.isLeftPanel ? iconBox.right : undefined)
-            : undefined
-        anchors.right: tasksRoot.vertical
-            ? (tasksRoot.isLeftPanel ? undefined : iconBox.left)
-            : undefined
-
+        anchors.bottom: tasksRoot.vertical ? undefined : (tasksRoot.isTopPanel ? undefined : iconBox.top)
+        anchors.top: tasksRoot.vertical ? undefined : (tasksRoot.isTopPanel ? iconBox.bottom : undefined)
+        anchors.left: tasksRoot.vertical ? (tasksRoot.isLeftPanel ? iconBox.right : undefined) : undefined
+        anchors.right: tasksRoot.vertical ? (tasksRoot.isLeftPanel ? undefined : iconBox.left) : undefined
         anchors.bottomMargin: (!tasksRoot.vertical && !tasksRoot.isTopPanel) ? 4 : 0
         anchors.topMargin: (!tasksRoot.vertical && tasksRoot.isTopPanel) ? 4 : 0
         anchors.leftMargin: (tasksRoot.vertical && tasksRoot.isLeftPanel) ? 4 : 0
         anchors.rightMargin: (tasksRoot.vertical && !tasksRoot.isLeftPanel) ? 4 : 0
-
-        width: 20
-        height: 20
-        z: 10
-
-        Rectangle {
-            anchors.fill: parent
-            radius: width / 2
-            color: Qt.rgba(0, 0, 0, 0.7)
-            border.color: Qt.rgba(1, 1, 1, 0.5)
-            border.width: 1
-            antialiasing: true
-        }
-
-        PlasmaComponents3.Label {
-            anchors.centerIn: parent
-            text: (task.index + 1).toString()
-            font.pixelSize: 11
-            font.bold: true
-            color: "#ffffff"
-            horizontalAlignment: Text.AlignHCenter
-            verticalAlignment: Text.AlignVCenter
-        }
+        width: 20; height: 20; z: 10
+        Rectangle { anchors.fill: parent; radius: width / 2; color: Qt.rgba(0, 0, 0, 0.7); border.color: Qt.rgba(1, 1, 1, 0.5); border.width: 1; antialiasing: true }
+        PlasmaComponents3.Label { anchors.centerIn: parent; text: (task.index + 1).toString(); font.pixelSize: 11; font.bold: true; color: "#ffffff"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter }
     }
 
     PlasmaComponents3.Label {
         id: label
-
-        visible: (task.inPopup || !task.tasksRoot.iconsOnly && !task.model.IsLauncher
-        && (parent.width - iconBox.height - Kirigami.Units.smallSpacing) >= LayoutMetrics.spaceRequiredToShowText())
-
-        anchors {
-            fill: parent
-            leftMargin: taskFrame.margins.left + iconBox.width + LayoutMetrics.labelMargin
-            topMargin: taskFrame.margins.top
-            rightMargin: taskFrame.margins.right + (task.audioStreamIcon !== null && task.audioStreamIcon.visible ? (task.audioStreamIcon.width + LayoutMetrics.labelMargin) : 0)
-            bottomMargin: taskFrame.margins.bottom
-        }
-
-        wrapMode: (maximumLineCount === 1) ? Text.NoWrap : Text.Wrap
-        elide: Text.ElideRight
-        textFormat: Text.PlainText
-        verticalAlignment: Text.AlignVCenter
+        visible: (task.inPopup || !task.tasksRoot.iconsOnly && !task.model.IsLauncher && (parent.width - iconBox.height - Kirigami.Units.smallSpacing) >= LayoutMetrics.spaceRequiredToShowText())
+        anchors { fill: parent; leftMargin: tasksRoot.taskFrame.margins.left + iconBox.width + LayoutMetrics.labelMargin; topMargin: tasksRoot.taskFrame.margins.top; rightMargin: tasksRoot.taskFrame.margins.right + (task.audioStreamIcon !== null && task.audioStreamIcon.visible ? (task.audioStreamIcon.width + LayoutMetrics.labelMargin) : 0); bottomMargin: tasksRoot.taskFrame.margins.bottom }
+        wrapMode: (maximumLineCount === 1) ? Text.NoWrap : Text.Wrap; elide: Text.ElideRight; textFormat: Text.PlainText; verticalAlignment: Text.AlignVCenter
         maximumLineCount: Plasmoid.configuration.maxTextLines || undefined
-
-        // The accessible item of this element is only used for debugging
-        // purposes, and it will never gain focus (thus it won't interfere
-        // with screenreaders).
         Accessible.ignored: !visible
-        Accessible.name: parent.Accessible.name + "-labelhint"
-
-        // use State to avoid unnecessary re-evaluation when the label is invisible
-        states: State {
-            name: "labelVisible"
-            when: label.visible
-
-            PropertyChanges {
-                label.text: task.model.display
-            }
-        }
+        states: State { name: "labelVisible"; when: label.visible; PropertyChanges { label.text: task.model.display } }
     }
 
     states: [
-        State {
-            name: "launcher"
-            when: task.model.IsLauncher
-
-            PropertyChanges {
-                frame.basePrefix: ""
-            }
-        },
-        State {
-            name: "attention"
-            when: task.model.IsDemandingAttention || (task.smartLauncherItem && task.smartLauncherItem.urgent)
-
-            PropertyChanges {
-                frame.basePrefix: "attention"
-            }
-        },
-        State {
-            name: "minimized"
-            when: task.model.IsMinimized
-
-            PropertyChanges {
-                frame.basePrefix: "minimized"
-            }
-        },
-        State {
-            name: "active"
-            when: task.model.IsActive
-
-            PropertyChanges {
-                frame.basePrefix: "focus"
-            }
-        }
+        State { name: "launcher"; when: task.model.IsLauncher; PropertyChanges { frame.basePrefix: "" } },
+        State { name: "attention"; when: task.model.IsDemandingAttention || (task.smartLauncherItem && task.smartLauncherItem.urgent); PropertyChanges { frame.basePrefix: "attention" } },
+        State { name: "minimized"; when: task.model.IsMinimized; PropertyChanges { frame.basePrefix: "minimized" } },
+        State { name: "active"; when: task.model.IsActive; PropertyChanges { frame.basePrefix: "focus" } }
     ]
 
     Component.onCompleted: {
@@ -920,22 +466,10 @@ PlasmaCore.ToolTipArea {
             component.createObject(task);
             component.destroy();
             updateAudioStreams({delay: false});
-            console.log(
-                "iconBox y=", iconBox.y,
-                "iconBox x=", iconBox.x,
-                "top=", iconBox.anchors.top,
-                "bottom=", iconBox.anchors.bottom
-            );
         }
-
         if (!inPopup && !model.IsWindow) {
-            taskInitComponent.createObject(task);
+            tasksRoot.taskInitComponent.createObject(task);
         }
         completed = true;
-    }
-    Component.onDestruction: {
-        /* if (moveAnim.running) {
-         *           (task.parent as TaskList).animationsRunning -= 1;
-    } */
     }
 }

--- a/package/contents/ui/Task.qml
+++ b/package/contents/ui/Task.qml
@@ -26,19 +26,31 @@ PlasmaCore.ToolTipArea {
 
     activeFocusOnTab: true
 
+    // To achieve a bottom-to-top layout on vertical panels, the task manager
+    // is rotated by 180 degrees(see main.qml). This makes the tasks rotated,
+    // so un-rotate them here to fix that.
     rotation: Plasmoid.configuration.reverseMode && Plasmoid.formFactor === PlasmaCore.Types.Vertical ? 180 : 0
 
-    implicitHeight: inPopup ? LayoutMetrics.preferredHeightInPopup() : (tasksRoot.vertical ? LayoutMetrics.preferredMinHeight() : Math.max(tasksRoot.height / Plasmoid.configuration.maxStripes, LayoutMetrics.preferredMinHeight()))
-    implicitWidth: tasksRoot.vertical ? Math.max(LayoutMetrics.preferredMinWidth(), Math.min(LayoutMetrics.preferredMaxWidth(), tasksRoot.width / Plasmoid.configuration.maxStripes)) : 0
+    implicitHeight: inPopup
+    ? LayoutMetrics.preferredHeightInPopup()
+    : (tasksRoot.vertical
+    ? LayoutMetrics.preferredMinHeight()
+    : Math.max(tasksRoot.height / Plasmoid.configuration.maxStripes,
+               LayoutMetrics.preferredMinHeight()))
+    implicitWidth: tasksRoot.vertical
+    ? Math.max(LayoutMetrics.preferredMinWidth(), Math.min(LayoutMetrics.preferredMaxWidth(), tasksRoot.width / Plasmoid.configuration.maxStripes))
+    : 0
 
     Layout.fillWidth: true
     Layout.fillHeight: !inPopup
-    Layout.maximumWidth: tasksRoot.vertical ? -1 : ((model.IsLauncher && !tasksRoot.iconsOnly) ? tasksRoot.height / taskList.rows : LayoutMetrics.preferredMaxWidth())
+    Layout.maximumWidth: tasksRoot.vertical
+    ? -1
+    : ((model.IsLauncher && !tasksRoot.iconsOnly) ? tasksRoot.height / taskList.rows : LayoutMetrics.preferredMaxWidth())
     Layout.maximumHeight: tasksRoot.vertical ? LayoutMetrics.preferredMaxHeight() : -1
 
     required property var model
     required property int index
-    required property Item tasksRoot
+    required property /*main.qml*/ Item tasksRoot
 
     readonly property int pid: model.AppPid
     readonly property string appName: model.AppName
@@ -64,54 +76,124 @@ PlasmaCore.ToolTipArea {
     readonly property bool playingAudio: hasAudioStream && audioStreams.some(item => !item.corked)
     readonly property bool muted: hasAudioStream && audioStreams.every(item => item.muted)
 
-    readonly property bool highlighted: (inPopup && activeFocus) || (!inPopup && containsMouse) || (task.contextMenu && task.contextMenu.status === PlasmaExtras.Menu.Open) || (!!tasksRoot.groupDialog && tasksRoot.groupDialog.visualParent === task)
+    readonly property bool highlighted: (inPopup && activeFocus) || (!inPopup && containsMouse)
+    || (task.contextMenu && task.contextMenu.status === PlasmaExtras.Menu.Open)
+    || (!!tasksRoot.groupDialog && tasksRoot.groupDialog.visualParent === task)
 
     active: !inPopup && !tasksRoot.groupDialog && task.contextMenu?.status !== PlasmaExtras.Menu.Open
     interactive: model.IsWindow || mainItem.playerData
     location: Plasmoid.location
     mainItem: !Plasmoid.configuration.showToolTips || !model.IsWindow ? pinnedAppToolTipDelegate : openWindowToolTipDelegate
 
+    // y hace que el panel se expanda elásticamente.
     width: Plasmoid.configuration.iconSize
     height: tasksRoot.height
+
+    // Desactivamos el recorte para que el zoom y el reflejo "vuelen" fuera
     clip: false
 
+    // Esta propiedad la activamos desde el MouseArea del main.qml
     property bool isHovered: false
-    property Item dockRef: null
+
+    property Item dockRef: null // Esto recibirá el 'dockMouseArea' de main.qml
 
     readonly property real _baseSize: Plasmoid.configuration.iconSize
     readonly property real _sigma: _baseSize * Plasmoid.configuration.amplitud
     readonly property real _zoom: (Plasmoid.configuration.magnification || 0) / 100
 
+    // ---------------------------------------------------------
+    // INICIO DEL CÓDIGO ZOOM (OSX EFFECT)
+    // ---------------------------------------------------------
+
     property real zoomFactor: {
+
         if (!dockRef || _zoom <= 0) return 1.0;
+
         let mousePos = dockRef.smoothMouse;
+
         if (mousePos < 0) return 1.0;
 
+        // Tamaño total SIN zoom
         let totalSize = tasksRoot.taskRepeater.count * _baseSize;
-        let availableSize = tasksRoot.vertical ? tasksRoot.taskList.height : tasksRoot.taskList.width;
+
+        // Área disponible según orientación
+        let availableSize = tasks.vertical
+        ? tasksRoot.taskList.height
+        : tasksRoot.taskList.width;
+
+        // Offset centrado
         let centerOffset = (availableSize - totalSize) / 2;
+
+        // Centro del icono actual
         let iconCenter = centerOffset + (index * _baseSize) + (_baseSize / 2);
+
+        // Distancia mouse-icono
         let distance = Math.abs(mousePos - iconCenter);
 
+        // Corte para rendimiento
         if (distance > _sigma * 3) return 1.0;
+
+        // Entrada/salida animada
         let dynamicZoom = _zoom * entryProgress;
+
+        // Curva gaussiana tipo macOS
         return 1.0 + dynamicZoom * Math.exp(-(Math.pow(distance, 2) / (2 * Math.pow(_sigma, 2))));
     }
 
     property real entryProgress: (dockRef && dockRef.insideDock) ? 1.0 : 0.0
 
     Behavior on entryProgress {
-        NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+        NumberAnimation {
+            duration: 200
+            easing.type: Easing.OutCubic
+        }
     }
 
     Accessible.name: model.display
+    Accessible.description: {
+        if (!model.display) {
+            return "";
+        }
+
+        if (model.IsLauncher) {
+            return i18nc("@info:usagetip %1 application name", "Launch %1", model.display)
+        }
+
+        let smartLauncherDescription = "";
+        if (iconBox.active) {
+            smartLauncherDescription += i18ncp("@info:tooltip", "There is %1 new message.", "There are %1 new messages.", task.smartLauncherItem.count);
+        }
+
+        if (model.IsGroupParent) {
+            switch (Plasmoid.configuration.groupedTaskVisualization) {
+                case 0:
+                    break; // Use the default description
+                case 1: {
+                    return `${i18nc("@info:usagetip %1 task name", "Show Task tooltip for %1", model.display)}; ${smartLauncherDescription}`;
+                }
+                case 2: {
+                    if (effectWatcher.registered) {
+                        return `${i18nc("@info:usagetip %1 task name", "Show windows side by side for %1", model.display)}; ${smartLauncherDescription}`;
+                    }
+                    // fallthrough
+                }
+                default:
+                    return `${i18nc("@info:usagetip %1 task name", "Open textual list of windows for %1", model.display)}; ${smartLauncherDescription}`;
+            }
+        }
+
+        return `${i18nc("@info:usagetip %1 task name", "Activate %1", model.display)}; ${smartLauncherDescription}`;
+    }
     Accessible.role: Accessible.Button
     Accessible.onPressAction: leftTapHandler.leftClick()
 
     onToolTipVisibleChanged: toolTipVisible => {
         task.toolTipOpen = toolTipVisible;
-        if (!toolTipVisible) tasksRoot.toolTipOpenedByClick = null;
-        else tasksRoot.toolTipAreaItem = task;
+        if (!toolTipVisible) {
+            tasksRoot.toolTipOpenedByClick = null;
+        } else {
+            tasksRoot.toolTipAreaItem = task;
+        }
     }
 
     onContainsMouseChanged: {
@@ -123,29 +205,36 @@ PlasmaCore.ToolTipArea {
         }
     }
 
-    onHighlightedChanged: { tasksRoot.cancelHighlightWindows(); }
+    onHighlightedChanged: {
+        // ensure it doesn't get stuck with a window highlighted
+        tasksRoot.cancelHighlightWindows();
+    }
+
     onPidChanged: updateAudioStreams({delay: false})
     onAppNameChanged: updateAudioStreams({delay: false})
 
     onIsWindowChanged: {
         if (model.IsWindow) {
-            tasksRoot.taskInitComponent.createObject(task);
+            taskInitComponent.createObject(task);
             updateAudioStreams({delay: false});
         }
     }
 
     onChildCountChanged: {
         if (TaskTools.taskManagerInstanceCount < 2 && childCount > previousChildCount) {
-            tasksRoot.tasksModel.requestPublishDelegateGeometry(modelIndex(), tasksRoot.backend.globalRect(task), task);
+            tasksModel.requestPublishDelegateGeometry(modelIndex(), backend.globalRect(task), task);
         }
+
         previousChildCount = childCount;
     }
 
     onIndexChanged: {
         hideToolTip();
-        if (!inPopup && !tasksRoot.vertical && !Plasmoid.configuration.separateLaunchers) {
+
+        if (!inPopup && !tasksRoot.vertical
+            && !Plasmoid.configuration.separateLaunchers) {
             tasksRoot.requestLayout();
-        }
+            }
     }
 
     onSmartLauncherEnabledChanged: {
@@ -153,7 +242,9 @@ PlasmaCore.ToolTipArea {
             const component = Qt.createComponent("org.vicko.wavetask", "SmartLauncherItem");
             const smartLauncher = component.createObject(task);
             component.destroy();
+
             smartLauncher.launcherUrl = Qt.binding(() => model.LauncherUrlWithoutIcon);
+
             smartLauncherItem = smartLauncher;
         }
     }
@@ -167,6 +258,8 @@ PlasmaCore.ToolTipArea {
             }
             return;
         }
+        // Create item on demand instead of using Loader to reduce memory consumption,
+        // because only a few applications have audio streams.
         const component = Qt.createComponent("AudioStream.qml");
         audioStreamIcon = component.createObject(task);
         component.destroy();
@@ -175,49 +268,93 @@ PlasmaCore.ToolTipArea {
 
     Keys.onMenuPressed: event => contextMenuTimer.start()
     Keys.onReturnPressed: event => TaskTools.activateTask(modelIndex(), model, event.modifiers, task, Plasmoid, tasksRoot, effectWatcher.registered)
-    Keys.onEnterPressed: event => Keys.returnPressed(event)
-    Keys.onSpacePressed: event => Keys.returnPressed(event)
+    Keys.onEnterPressed: event => Keys.returnPressed(event);
+    Keys.onSpacePressed: event => Keys.returnPressed(event);
     Keys.onUpPressed: event => Keys.leftPressed(event)
     Keys.onDownPressed: event => Keys.rightPressed(event)
+    Keys.onLeftPressed: event => {
+        if (!inPopup && (event.modifiers & Qt.ControlModifier) && (event.modifiers & Qt.ShiftModifier)) {
+            tasksModel.move(task.index, task.index - 1);
+        } else {
+            event.accepted = false;
+        }
+    }
+    Keys.onRightPressed: event => {
+        if (!inPopup && (event.modifiers & Qt.ControlModifier) && (event.modifiers & Qt.ShiftModifier)) {
+            tasksModel.move(task.index, task.index + 1);
+        } else {
+            event.accepted = false;
+        }
+    }
 
-    function modelIndex(): var {
-        return inPopup ? tasksRoot.tasksModel.makeModelIndex(groupDialog.visualParent.index, index) : tasksRoot.tasksModel.makeModelIndex(index);
+    function modelIndex(): /*QModelIndex*/ var {
+        return inPopup
+        ? tasksModel.makeModelIndex(groupDialog.visualParent.index, index)
+        : tasksModel.makeModelIndex(index);
     }
 
     function showContextMenu(args: var): void {
         task.hideImmediately();
-        contextMenu = tasksRoot.createContextMenu(task, modelIndex(), args);
+        contextMenu = tasksRoot.createContextMenu(task, modelIndex(), args) as ContextMenu;
         contextMenu.show();
     }
 
     function updateAudioStreams(args: var): void {
-        if (args) delayAudioStreamIndicator = !!args.delay;
-        var pa = tasksRoot.pulseAudio.item;
+        if (args) {
+            // When the task just appeared (e.g. virtual desktop switch), show the audio indicator
+            // right away. Only when audio streams change during the lifetime of this task, delay
+            // showing that to avoid distraction.
+            delayAudioStreamIndicator = !!args.delay;
+        }
+
+        var pa = pulseAudio.item;
         if (!pa || !task.isWindow) {
             task.audioStreams = [];
             return;
         }
+
+        // Check appid first for app using portal
+        // https://docs.pipewire.org/page_portal.html
         var streams = pa.streamsForAppId(task.appId);
         if (!streams.length) {
             streams = pa.streamsForPid(model.AppPid);
-            if (streams.length) pa.registerPidMatch(model.AppName);
-            else if (!pa.hasPidMatch(model.AppName)) streams = pa.streamsForAppName(model.AppName);
+            if (streams.length) {
+                pa.registerPidMatch(model.AppName);
+            } else {
+                // We only want to fall back to appName matching if we never managed to map
+                // a PID to an audio stream window. Otherwise if you have two instances of
+                // an application, one playing and the other not, it will look up appName
+                // for the non-playing instance and erroneously show an indicator on both.
+                if (!pa.hasPidMatch(model.AppName)) {
+                    streams = pa.streamsForAppName(model.AppName);
+                }
+            }
         }
+
         task.audioStreams = streams;
     }
 
     function toggleMuted(): void {
-        if (muted) task.audioStreams.forEach(item => item.unmute());
-        else task.audioStreams.forEach(item => item.mute());
+        if (muted) {
+            task.audioStreams.forEach(item => item.unmute());
+        } else {
+            task.audioStreams.forEach(item => item.mute());
+        }
     }
 
+    // Will also be called in activateTaskAtIndex(index)
     function updateMainItemBindings(): void {
-        if ((mainItem.parentTask === this && mainItem.rootIndex.row === index) || (tasksRoot.toolTipOpenedByClick === null && !active) || (tasksRoot.toolTipOpenedByClick !== null && tasksRoot.toolTipOpenedByClick !== this)) {
+        if ((mainItem.parentTask === this && mainItem.rootIndex.row === index)
+            || (tasksRoot.toolTipOpenedByClick === null && !active)
+            || (tasksRoot.toolTipOpenedByClick !== null && tasksRoot.toolTipOpenedByClick !== this)) {
             return;
-        }
-        mainItem.blockingUpdates = (mainItem.isGroup !== model.IsGroupParent);
-        mainItem.parentTask = this;
-        mainItem.rootIndex = tasksRoot.tasksModel.makeModelIndex(index, -1);
+            }
+
+            mainItem.blockingUpdates = (mainItem.isGroup !== model.IsGroupParent); // BUG 464597 Force unload the previous component
+
+            mainItem.parentTask = this;
+        mainItem.rootIndex = tasksModel.makeModelIndex(index, -1);
+
         mainItem.appName = Qt.binding(() => model.AppName);
         mainItem.pidParent = Qt.binding(() => model.AppPid);
         mainItem.windows = Qt.binding(() => model.WinIdList);
@@ -231,77 +368,189 @@ PlasmaCore.ToolTipArea {
         mainItem.virtualDesktops = Qt.binding(() => model.VirtualDesktops);
         mainItem.isOnAllVirtualDesktops = Qt.binding(() => model.IsOnAllVirtualDesktops);
         mainItem.activities = Qt.binding(() => model.Activities);
+
         mainItem.smartLauncherCountVisible = Qt.binding(() => smartLauncherItem?.countVisible ?? false);
         mainItem.smartLauncherCount = Qt.binding(() => mainItem.smartLauncherCountVisible ? (smartLauncherItem?.count ?? 0) : 0);
+
         mainItem.blockingUpdates = false;
         tasksRoot.toolTipAreaItem = this;
     }
 
+    Connections {
+        target: pulseAudio.item
+        ignoreUnknownSignals: true // Plasma-PA might not be available
+        function onStreamsChanged(): void {
+            task.updateAudioStreams({delay: true})
+        }
+    }
+
+    TapHandler {
+        id: menuTapHandler
+        acceptedButtons: Qt.LeftButton
+        acceptedDevices: PointerDevice.TouchScreen | PointerDevice.Stylus
+        gesturePolicy: TapHandler.ReleaseWithinBounds
+        onLongPressed: {
+            // When we're a launcher, there's no window controls, so we can show all
+            // places without the menu getting super huge.
+            if (task.model.IsLauncher) {
+                task.showContextMenu({showAllPlaces: true})
+            } else {
+                task.showContextMenu();
+            }
+        }
+    }
+
+    TapHandler {
+        acceptedButtons: Qt.RightButton
+        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.Stylus
+        gesturePolicy: TapHandler.WithinBounds // Release grab when menu appears
+        onPressedChanged: if (pressed) contextMenuTimer.start()
+    }
+
+    Timer {
+        id: contextMenuTimer
+        interval: 0
+        onTriggered: menuTapHandler.longPressed()
+    }
+
+    TapHandler {
+        id: leftTapHandler
+        acceptedButtons: Qt.LeftButton
+        onTapped: (eventPoint, button) => leftClick()
+
+        function leftClick(): void {
+            if (task.active) {
+                task.hideToolTip();
+            }
+            TaskTools.activateTask(modelIndex(), model, point.modifiers, task, Plasmoid, tasksRoot, effectWatcher.registered);
+        }
+    }
+
+    TapHandler {
+        acceptedButtons: Qt.MiddleButton | Qt.BackButton | Qt.ForwardButton
+        onTapped: (eventPoint, button) => {
+            if (button === Qt.MiddleButton) {
+                if (Plasmoid.configuration.middleClickAction === TaskManagerApplet.Backend.NewInstance) {
+                    tasksModel.requestNewInstance(modelIndex());
+                } else if (Plasmoid.configuration.middleClickAction === TaskManagerApplet.Backend.Close) {
+                    tasksModel.requestClose(modelIndex());
+                } else if (Plasmoid.configuration.middleClickAction === TaskManagerApplet.Backend.ToggleMinimized) {
+                    tasksModel.requestToggleMinimized(modelIndex());
+                } else if (Plasmoid.configuration.middleClickAction === TaskManagerApplet.Backend.ToggleGrouping) {
+                    tasksModel.requestToggleGrouping(modelIndex());
+                } else if (Plasmoid.configuration.middleClickAction === TaskManagerApplet.Backend.BringToCurrentDesktop) {
+                    tasksModel.requestVirtualDesktops(modelIndex(), [virtualDesktopInfo.currentDesktop]);
+                }
+            } else if (button === Qt.BackButton || button === Qt.ForwardButton) {
+                const playerData = mpris2Source.playerForLauncherUrl(task.model.LauncherUrlWithoutIcon, task.model.AppPid);
+                if (playerData) {
+                    if (button === Qt.BackButton) {
+                        playerData.Previous();
+                    } else {
+                        playerData.Next();
+                    }
+                } else {
+                    eventPoint.accepted = false;
+                }
+            }
+
+            task.tasksRoot.cancelHighlightWindows();
+        }
+    }
+
     KSvg.FrameSvgItem {
         id: frame
-        anchors {
+
+          anchors {
             fill: parent
+
             topMargin: {
-                if (!task.tasksRoot.vertical && tasksRoot.taskList.rows > 1) return LayoutMetrics.iconMargin;
-                let iconAlign = Math.round(parent.height - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing;
-                let indicatorOffset = -Kirigami.Units.gridUnit / tasksRoot.skinParams.positionTaskIndicator;
-                return tasksRoot.isTopPanel ? indicatorOffset : iconAlign;
+                if (!task.tasksRoot.vertical && taskList.rows > 1) {
+                    return LayoutMetrics.iconMargin
+                }
+
+                let iconAlign = Math.round(parent.height - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing
+                let indicatorOffset = -Kirigami.Units.gridUnit / tasks.skinParams.positionTaskIndicator
+
+                return tasksRoot.isTopPanel ? indicatorOffset : iconAlign
             }
             bottomMargin: {
-                if (!task.tasksRoot.vertical && tasksRoot.taskList.rows > 1) return LayoutMetrics.iconMargin;
-                let iconAlign = Math.round(parent.height - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing;
-                let indicatorOffset = -Kirigami.Units.gridUnit / tasksRoot.skinParams.positionTaskIndicator;
-                return tasksRoot.isTopPanel ? iconAlign : indicatorOffset;
+                if (!task.tasksRoot.vertical && taskList.rows > 1) {
+                    return LayoutMetrics.iconMargin
+                }
+
+                let iconAlign = Math.round(parent.height - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing
+                let indicatorOffset = -Kirigami.Units.gridUnit / tasks.skinParams.positionTaskIndicator
+
+                return tasksRoot.isTopPanel ? iconAlign : indicatorOffset
             }
             leftMargin: {
-                if ((inPopup || tasksRoot.vertical) && tasksRoot.taskList.columns > 1) return LayoutMetrics.iconMargin;
-                let iconAlign = Math.round(parent.width - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing * 0.5;
-                let indicatorOffset = -Kirigami.Units.gridUnit / tasksRoot.skinParams.positionTaskIndicator;
-                return tasksRoot.isLeftPanel ? indicatorOffset : iconAlign;
+                if ((inPopup || tasksRoot.vertical) && taskList.columns > 1) {
+                    return LayoutMetrics.iconMargin
+                }
+
+                let iconAlign = Math.round(parent.width - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing * 0.5
+                let indicatorOffset = -Kirigami.Units.gridUnit / tasks.skinParams.positionTaskIndicator
+
+                return tasksRoot.isLeftPanel ? indicatorOffset : iconAlign
             }
             rightMargin: {
-                if (!task.tasksRoot.vertical && tasksRoot.taskList.rows > 1) return LayoutMetrics.iconMargin;
-                let iconAlign = Math.round(parent.width - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing * 0.5;
-                let indicatorOffset = -Kirigami.Units.gridUnit / tasksRoot.skinParams.positionTaskIndicator;
-                return tasksRoot.isLeftPanel ? iconAlign : indicatorOffset;
+                if (!task.tasksRoot.vertical && taskList.rows > 1) {
+                    return LayoutMetrics.iconMargin
+                }
+
+                let iconAlign = Math.round(parent.width - Plasmoid.configuration.iconSize * zoomFactor) - Kirigami.Units.smallSpacing * 0.5
+                let indicatorOffset = -Kirigami.Units.gridUnit / tasks.skinParams.positionTaskIndicator
+
+                return tasksRoot.isLeftPanel ? iconAlign : indicatorOffset
             }
         }
 
-        imagePath: (Plasmoid.configuration.skinName === "Default Plasma") ? "widgets/tasks" : tasksRoot.skinParams.imagetask
+        imagePath: (Plasmoid.configuration.skinName === "Default Plasma") ? "widgets/tasks" : tasks.skinParams.imagetask
         property bool isHovered: task.highlighted && Plasmoid.configuration.taskHoverEffect
         property string basePrefix: "normal"
         prefix: isHovered ? TaskTools.taskPrefixHovered(basePrefix, Plasmoid.location) : TaskTools.taskPrefix(basePrefix, Plasmoid.location)
 
+
+        // Avoid repositioning delegate item after dragFinished
         DragHandler {
             id: dragHandler
             grabPermissions: PointerHandler.CanTakeOverFromHandlersOfDifferentType
+
             function setRequestedInhibitDnd(value: bool): void {
+                // This is modifying the value in the panel containment that
+                // inhibits accepting drag and drop, so that we don't accidentally
+                // drop the task on this panel.
                 let item = this;
                 while (item.parent) {
                     item = item.parent;
                     if (item.appletRequestsInhibitDnD !== undefined) {
-                        item.appletRequestsInhibitDnD = value;
+                        item.appletRequestsInhibitDnD = value
                     }
                 }
             }
+
             onActiveChanged: {
                 if (active) {
                     icon.grabToImage(result => {
-                        if (!dragHandler.active) return;
+                        if (!dragHandler.active) {
+                            // BUG 466675 grabToImage is async, so avoid updating dragSource when active is false
+                            return;
+                        }
                         setRequestedInhibitDnd(true);
                         tasksRoot.dragSource = task;
-                        tasksRoot.dragHelper.Drag.imageSource = result.url;
-                        tasksRoot.dragHelper.Drag.mimeData = {
-                            "text/x-orgkdeplasmataskmanager_taskurl": tasksRoot.backend.tryDecodeApplicationsUrl(model.LauncherUrlWithoutIcon).toString(),
+                        dragHelper.Drag.imageSource = result.url;
+                        dragHelper.Drag.mimeData = {
+                            "text/x-orgkdeplasmataskmanager_taskurl": backend.tryDecodeApplicationsUrl(model.LauncherUrlWithoutIcon).toString(),
                                      [model.MimeType]: model.MimeData,
                                      "application/x-orgkdeplasmataskmanager_taskbuttonitem": model.MimeData,
                         };
-                        tasksRoot.dragHelper.Drag.active = dragHandler.active;
+                        dragHelper.Drag.active = dragHandler.active;
                     });
                 } else {
                     setRequestedInhibitDnd(false);
-                    tasksRoot.dragHelper.Drag.active = false;
-                    tasksRoot.dragHelper.Drag.imageSource = "";
+                    dragHelper.Drag.active = false;
+                    dragHelper.Drag.imageSource = "";
                 }
             }
         }
@@ -309,155 +558,360 @@ PlasmaCore.ToolTipArea {
 
     Loader {
         id: taskProgressOverlayLoader
+
         anchors.fill: frame
         asynchronous: true
         active: task.smartLauncherItem && task.smartLauncherItem.progressVisible
+
         source: "TaskProgressOverlay.qml"
     }
 
-    Loader {
-        id: iconBox
-        width: Plasmoid.configuration.iconSize
-        height: Plasmoid.configuration.iconSize
-        anchors.centerIn: tasksRoot.vertical ? parent : undefined
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: ((!tasksRoot.vertical) && Plasmoid.location === PlasmaCore.Types.BottomEdge) ? 0 : Math.round((tasksRoot.height / 2) - (Kirigami.Units.iconSizes.small * 0.14))
-        anchors.horizontalCenter: (!tasksRoot.vertical) ? parent.horizontalCenter : undefined
-
-        property int baseRenderSize: Plasmoid.configuration.iconSize * 2
-        property Item visualIcon: icon // Expose to sub-loaded contexts safely
-
-        SequentialAnimation {
-            id: bounceAnimation
-            running: task.model.IsStartup || task.model.IsDemandingAttention || (task.smartLauncherItem && task.smartLauncherItem.urgent)
-            loops: Animation.Infinite
-            alwaysRunToEnd: true
-            property real jumpHeight: {
-                let currentSize = Plasmoid.configuration.iconSize * zoomFactor;
-                let idealJump = currentSize * 0.6;
-                let headroom = Math.max(0, tasksRoot.height - Plasmoid.configuration.iconSize);
-                return Math.min(idealJump, headroom);
-            }
-            NumberAnimation { target: iconBox; property: "anchors.bottomMargin"; from: 0; to: bounceAnimation.jumpHeight; duration: 300; easing.type: Easing.OutQuad }
-            NumberAnimation { target: iconBox; property: "anchors.bottomMargin"; to: 0; duration: 300; easing.type: Easing.InQuad }
-        }
-
-        scale: zoomFactor
-        transformOrigin: {
-            switch (Plasmoid.location) {
-                case PlasmaCore.Types.BottomEdge: return Item.Bottom;
-                case PlasmaCore.Types.TopEdge: return Item.Top;
-                case PlasmaCore.Types.LeftEdge: return Item.Left;
-                case PlasmaCore.Types.RightEdge: return Item.Right;
-                default: return Item.Bottom;
-            }
-        }
-
-        asynchronous: true
-        active: task.smartLauncherItem && task.smartLauncherItem.countVisible
-        source: "TaskBadgeOverlay.qml"
-
-        function adjustMargin(isVertical: bool, size: real, margin: real): real {
-            if (!size) return margin;
-            var margins = isVertical ? LayoutMetrics.horizontalMargins() : LayoutMetrics.verticalMargins();
-            if ((size - margins) < Kirigami.Units.iconSizes.small) return Math.ceil((margin * (Kirigami.Units.iconSizes.small / size)) / 2);
-            return margin;
-        }
-
-        Kirigami.Icon {
-            id: icon
-            width: iconBox.baseRenderSize
-            height: iconBox.baseRenderSize
-            source: model.decoration
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.bottom: parent.bottom
-            anchors.bottomMargin: tasksRoot.isTopPanel ? 0 : Kirigami.Units.smallSpacing
-            anchors.topMargin: tasksRoot.isTopPanel ? Kirigami.Units.smallSpacing : 0
-            transformOrigin: Item.Bottom
-            scale: 1 / (iconBox.baseRenderSize / iconBox.width)
-            smooth: true; antialiasing: true
-        }
-
-        Item {
-            id: reflectionContainer
-            visible: Plasmoid.configuration.showReflection
-            opacity: 0.4; clip: true; z: -5
-            width: tasksRoot.vertical ? iconBox.width / 2 : iconBox.width
-            height: tasksRoot.vertical ? iconBox.height : iconBox.height / 2
-            x: {
-                switch (Plasmoid.location) {
-                    case PlasmaCore.Types.LeftEdge: return -width - Kirigami.Units.smallSpacing * 2.5;
-                    case PlasmaCore.Types.RightEdge: return iconBox.width + Kirigami.Units.smallSpacing * 2.5;
-                    default: return 0;
-                }
-            }
-            y: {
-                switch (Plasmoid.location) {
-                    case PlasmaCore.Types.TopEdge: return -height - Kirigami.Units.smallSpacing * 2;
-                    case PlasmaCore.Types.BottomEdge: return iconBox.height + Kirigami.Units.smallSpacing * 2;
-                    default: return 0;
-                }
-            }
-            Kirigami.Icon {
-                id: reflectionIcon
-                width: icon.width; height: icon.height
-                source: icon.source; smooth: true; antialiasing: true
-                anchors.centerIn: parent
-                scale: icon.scale
-                transform: Scale { origin.x: reflectionIcon.width / 2; origin.y: reflectionIcon.height / 2; xScale: tasksRoot.vertical ? -1 : 1; yScale: tasksRoot.vertical ? 1 : -1 }
-            }
-        }
-
-        states: [
-            State {
-                name: "standalone"
-                when: !label.visible && task.parent
-                AnchorChanges { target: iconBox; anchors.left: undefined; anchors.horizontalCenter: parent.horizontalCenter }
-                PropertyChanges { target: iconBox; anchors.leftMargin: 0; width: Math.min(task.parent.minimumWidth, tasksRoot.height) - adjustMargin(true, task.width, tasksRoot.taskFrame.margins.left) - adjustMargin(true, task.width, tasksRoot.taskFrame.margins.right) }
-            }
-        ]
-
         Loader {
-            anchors.centerIn: parent
-            width: Plasmoid.configuration.iconSize; height: Plasmoid.configuration.iconSize
-            active: model.IsStartup
-            sourceComponent: busyIndicator
-        }
-    }
+            id: iconBox
 
+            // Mantenemos el contenedor con un tamaño fijo
+            width: Plasmoid.configuration.iconSize
+            height: Plasmoid.configuration.iconSize
+
+           anchors.centerIn: tasksRoot.vertical
+           ? parent
+           : undefined
+
+           anchors.bottom: ((!tasksRoot.vertical) && Plasmoid.location === PlasmaCore.Types.BottomEdge)
+           ? parent.bottom
+           : parent.bottom
+
+           anchors.bottomMargin: ((!tasksRoot.vertical) && Plasmoid.location === PlasmaCore.Types.BottomEdge)
+           ? 0
+           : Math.round((tasksRoot.height / 2) - (Kirigami.Units.iconSizes.small * 0.14))
+
+
+           anchors.horizontalCenter: (!tasksRoot.vertical)
+           ? parent.horizontalCenter
+           : undefined
+
+            property int baseRenderSize: Plasmoid.configuration.iconSize * 2
+
+            SequentialAnimation {
+                id: bounceAnimation
+                running: task.model.IsStartup || task.model.IsDemandingAttention || (task.smartLauncherItem && task.smartLauncherItem.urgent)
+                loops: Animation.Infinite
+                alwaysRunToEnd: true
+
+                // Calculamos la altura del salto considerando el factor de escala (zoom)
+                property real jumpHeight: {
+                    let currentSize = Plasmoid.configuration.iconSize * zoomFactor;
+                    let idealJump = currentSize * 0.6; // Salto base: 60% del tamaño del icono
+
+                    // Calculamos el espacio disponible para evitar que el icono se corte con el borde del panel
+                    let headroom = Math.max(0, tasksRoot.height - Plasmoid.configuration.iconSize);
+
+                    // Limitamos el salto al espacio real disponible
+                    return Math.min(idealJump, headroom);
+                }
+
+                // Animación de ascenso (impulso)
+                NumberAnimation {
+                    target: iconBox
+                    property: "anchors.bottomMargin"
+                    from: 0
+                    to: bounceAnimation.jumpHeight
+                    duration: 300
+                    easing.type: Easing.OutQuad
+                }
+
+                // Animación de descenso (gravedad)
+                NumberAnimation {
+                    target: iconBox
+                    property: "anchors.bottomMargin"
+                    to: 0
+                    duration: 300
+                    easing.type: Easing.InQuad
+                }
+            }
+
+            // El zoom se aplica solo como transformación visual al contenedor completo
+            scale: zoomFactor
+            transformOrigin: {
+                switch (Plasmoid.location) {
+                    case PlasmaCore.Types.BottomEdge:
+                        return Item.Bottom;
+
+                    case PlasmaCore.Types.TopEdge:
+                        return Item.Top;
+
+                    case PlasmaCore.Types.LeftEdge:
+                        return Item.Left;
+                    case PlasmaCore.Types.RightEdge:
+                        return Item.Right;
+
+                    default:
+                        return Item.Bottom;
+                }
+            }
+
+            asynchronous: true
+            active: task.smartLauncherItem && task.smartLauncherItem.countVisible
+            source: "TaskBadgeOverlay.qml"
+
+            function adjustMargin(isVertical: bool, size: real, margin: real): real {
+                if (!size) {
+                    return margin;
+                }
+
+                var margins = isVertical ? LayoutMetrics.horizontalMargins() : LayoutMetrics.verticalMargins();
+
+                if ((size - margins) < Kirigami.Units.iconSizes.small) {
+                    return Math.ceil((margin * (Kirigami.Units.iconSizes.small / size)) / 2);
+                }
+
+                return margin;
+            }
+
+            Kirigami.Icon {
+                id: icon
+
+                width: iconBox.baseRenderSize
+                height: iconBox.baseRenderSize
+
+                source: model.decoration
+
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.bottom: parent.bottom
+                anchors.bottomMargin: tasksRoot.isTopPanel ? 0 : Kirigami.Units.smallSpacing
+                anchors.topMargin: tasksRoot.isTopPanel ? Kirigami.Units.smallSpacing : 0
+
+
+                transformOrigin: Item.Bottom
+
+                scale: 1 / (iconBox.baseRenderSize / iconBox.width)
+
+                smooth: true
+                antialiasing: true
+            }
+
+            Item {
+                id: reflectionContainer
+
+                visible: Plasmoid.configuration.showReflection
+                opacity: 0.4
+                clip: true
+                z: -5
+
+                width: tasksRoot.vertical
+                ? iconBox.width / 2
+                : iconBox.width
+
+                height: tasksRoot.vertical
+                ? iconBox.height
+                : iconBox.height / 2
+
+                x: {
+                    switch (Plasmoid.location) {
+
+                        case PlasmaCore.Types.LeftEdge:
+                            return -width - Kirigami.Units.smallSpacing * 2.5
+
+                        case PlasmaCore.Types.RightEdge:
+                            return iconBox.width + Kirigami.Units.smallSpacing * 2.5
+
+                        default:
+                            return 0
+                    }
+                }
+
+                y: {
+                    switch (Plasmoid.location) {
+
+                        case PlasmaCore.Types.TopEdge:
+                            return -height - Kirigami.Units.smallSpacing * 2
+
+                        case PlasmaCore.Types.BottomEdge:
+                            return iconBox.height + Kirigami.Units.smallSpacing * 2
+
+                        default:
+                            return 0
+                    }
+                }
+
+                Kirigami.Icon {
+                    id: reflectionIcon
+
+                    width: icon.width
+                    height: icon.height
+
+                    source: icon.source
+                    smooth: true
+                    antialiasing: true
+
+                    anchors.centerIn: parent
+
+                    scale: icon.scale
+
+                    transform: Scale {
+                        origin.x: reflectionIcon.width / 2
+                        origin.y: reflectionIcon.height / 2
+
+                        xScale: tasksRoot.vertical ? -1 : 1
+                        yScale: tasksRoot.vertical ? 1 : -1
+                    }
+                }
+            }
+
+            states: [
+                // Using a state transition avoids a binding loop between label.visible and
+                // the text label margin, which derives from the icon width.
+                State {
+                    name: "standalone"
+                    when: !label.visible && task.parent
+
+                    AnchorChanges {
+                        target: iconBox
+                        anchors.left: undefined
+                        anchors.horizontalCenter: parent.horizontalCenter
+                    }
+
+                    PropertyChanges {
+                        target: iconBox
+                        anchors.leftMargin: 0
+                        width: Math.min(task.parent.minimumWidth, tasks.height)
+                        - adjustMargin(true, task.width, taskFrame.margins.left)
+                        - adjustMargin(true, task.width, taskFrame.margins.right)
+                    }
+                }
+            ]
+
+            Loader {
+                anchors.centerIn: parent
+                width: Plasmoid.configuration.iconSize
+                height: Plasmoid.configuration.iconSize
+                active: model.IsStartup
+                sourceComponent: busyIndicator
+            }
+        }
+
+    // --- META KEY TASK INDEX BADGE ---
     Item {
         id: metaIndexBadge
+
         visible: tasksRoot.metaShowActive && Plasmoid.configuration.showTaskNumbersOnMeta
+
+        // Position depends on panel location:
+        // Bottom panel: above icon; Top panel: below icon
+        // Left panel: right of icon; Right panel: left of icon
         anchors.horizontalCenter: tasksRoot.vertical ? undefined : iconBox.horizontalCenter
         anchors.verticalCenter: tasksRoot.vertical ? iconBox.verticalCenter : undefined
-        anchors.bottom: tasksRoot.vertical ? undefined : (tasksRoot.isTopPanel ? undefined : iconBox.top)
-        anchors.top: tasksRoot.vertical ? undefined : (tasksRoot.isTopPanel ? iconBox.bottom : undefined)
-        anchors.left: tasksRoot.vertical ? (tasksRoot.isLeftPanel ? iconBox.right : undefined) : undefined
-        anchors.right: tasksRoot.vertical ? (tasksRoot.isLeftPanel ? undefined : iconBox.left) : undefined
+
+        anchors.bottom: tasksRoot.vertical ? undefined
+            : (tasksRoot.isTopPanel ? undefined : iconBox.top)
+        anchors.top: tasksRoot.vertical ? undefined
+            : (tasksRoot.isTopPanel ? iconBox.bottom : undefined)
+        anchors.left: tasksRoot.vertical
+            ? (tasksRoot.isLeftPanel ? iconBox.right : undefined)
+            : undefined
+        anchors.right: tasksRoot.vertical
+            ? (tasksRoot.isLeftPanel ? undefined : iconBox.left)
+            : undefined
+
         anchors.bottomMargin: (!tasksRoot.vertical && !tasksRoot.isTopPanel) ? 4 : 0
         anchors.topMargin: (!tasksRoot.vertical && tasksRoot.isTopPanel) ? 4 : 0
         anchors.leftMargin: (tasksRoot.vertical && tasksRoot.isLeftPanel) ? 4 : 0
         anchors.rightMargin: (tasksRoot.vertical && !tasksRoot.isLeftPanel) ? 4 : 0
-        width: 20; height: 20; z: 10
-        Rectangle { anchors.fill: parent; radius: width / 2; color: Qt.rgba(0, 0, 0, 0.7); border.color: Qt.rgba(1, 1, 1, 0.5); border.width: 1; antialiasing: true }
-        PlasmaComponents3.Label { anchors.centerIn: parent; text: (task.index + 1).toString(); font.pixelSize: 11; font.bold: true; color: "#ffffff"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter }
+
+        width: 20
+        height: 20
+        z: 10
+
+        Rectangle {
+            anchors.fill: parent
+            radius: width / 2
+            color: Qt.rgba(0, 0, 0, 0.7)
+            border.color: Qt.rgba(1, 1, 1, 0.5)
+            border.width: 1
+            antialiasing: true
+        }
+
+        PlasmaComponents3.Label {
+            anchors.centerIn: parent
+            text: (task.index + 1).toString()
+            font.pixelSize: 11
+            font.bold: true
+            color: "#ffffff"
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
     }
 
     PlasmaComponents3.Label {
         id: label
-        visible: (task.inPopup || !task.tasksRoot.iconsOnly && !task.model.IsLauncher && (parent.width - iconBox.height - Kirigami.Units.smallSpacing) >= LayoutMetrics.spaceRequiredToShowText())
-        anchors { fill: parent; leftMargin: tasksRoot.taskFrame.margins.left + iconBox.width + LayoutMetrics.labelMargin; topMargin: tasksRoot.taskFrame.margins.top; rightMargin: tasksRoot.taskFrame.margins.right + (task.audioStreamIcon !== null && task.audioStreamIcon.visible ? (task.audioStreamIcon.width + LayoutMetrics.labelMargin) : 0); bottomMargin: tasksRoot.taskFrame.margins.bottom }
-        wrapMode: (maximumLineCount === 1) ? Text.NoWrap : Text.Wrap; elide: Text.ElideRight; textFormat: Text.PlainText; verticalAlignment: Text.AlignVCenter
+
+        visible: (task.inPopup || !task.tasksRoot.iconsOnly && !task.model.IsLauncher
+        && (parent.width - iconBox.height - Kirigami.Units.smallSpacing) >= LayoutMetrics.spaceRequiredToShowText())
+
+        anchors {
+            fill: parent
+            leftMargin: taskFrame.margins.left + iconBox.width + LayoutMetrics.labelMargin
+            topMargin: taskFrame.margins.top
+            rightMargin: taskFrame.margins.right + (task.audioStreamIcon !== null && task.audioStreamIcon.visible ? (task.audioStreamIcon.width + LayoutMetrics.labelMargin) : 0)
+            bottomMargin: taskFrame.margins.bottom
+        }
+
+        wrapMode: (maximumLineCount === 1) ? Text.NoWrap : Text.Wrap
+        elide: Text.ElideRight
+        textFormat: Text.PlainText
+        verticalAlignment: Text.AlignVCenter
         maximumLineCount: Plasmoid.configuration.maxTextLines || undefined
+
+        // The accessible item of this element is only used for debugging
+        // purposes, and it will never gain focus (thus it won't interfere
+        // with screenreaders).
         Accessible.ignored: !visible
-        states: State { name: "labelVisible"; when: label.visible; PropertyChanges { label.text: task.model.display } }
+        Accessible.name: parent.Accessible.name + "-labelhint"
+
+        // use State to avoid unnecessary re-evaluation when the label is invisible
+        states: State {
+            name: "labelVisible"
+            when: label.visible
+
+            PropertyChanges {
+                label.text: task.model.display
+            }
+        }
     }
 
     states: [
-        State { name: "launcher"; when: task.model.IsLauncher; PropertyChanges { frame.basePrefix: "" } },
-        State { name: "attention"; when: task.model.IsDemandingAttention || (task.smartLauncherItem && task.smartLauncherItem.urgent); PropertyChanges { frame.basePrefix: "attention" } },
-        State { name: "minimized"; when: task.model.IsMinimized; PropertyChanges { frame.basePrefix: "minimized" } },
-        State { name: "active"; when: task.model.IsActive; PropertyChanges { frame.basePrefix: "focus" } }
+        State {
+            name: "launcher"
+            when: task.model.IsLauncher
+
+            PropertyChanges {
+                frame.basePrefix: ""
+            }
+        },
+        State {
+            name: "attention"
+            when: task.model.IsDemandingAttention || (task.smartLauncherItem && task.smartLauncherItem.urgent)
+
+            PropertyChanges {
+                frame.basePrefix: "attention"
+            }
+        },
+        State {
+            name: "minimized"
+            when: task.model.IsMinimized
+
+            PropertyChanges {
+                frame.basePrefix: "minimized"
+            }
+        },
+        State {
+            name: "active"
+            when: task.model.IsActive
+
+            PropertyChanges {
+                frame.basePrefix: "focus"
+            }
+        }
     ]
 
     Component.onCompleted: {
@@ -466,10 +920,22 @@ PlasmaCore.ToolTipArea {
             component.createObject(task);
             component.destroy();
             updateAudioStreams({delay: false});
+            console.log(
+                "iconBox y=", iconBox.y,
+                "iconBox x=", iconBox.x,
+                "top=", iconBox.anchors.top,
+                "bottom=", iconBox.anchors.bottom
+            );
         }
+
         if (!inPopup && !model.IsWindow) {
-            tasksRoot.taskInitComponent.createObject(task);
+            taskInitComponent.createObject(task);
         }
         completed = true;
+    }
+    Component.onDestruction: {
+        /* if (moveAnim.running) {
+         *           (task.parent as TaskList).animationsRunning -= 1;
+    } */
     }
 }

--- a/package/contents/ui/TaskBadgeOverlay.qml
+++ b/package/contents/ui/TaskBadgeOverlay.qml
@@ -1,8 +1,8 @@
 /*
-    SPDX-FileCopyrightText: 2016 Kai Uwe Broulik <kde@privat.broulik.de>
-
-    SPDX-License-Identifier: GPL-2.0-or-later
-*/
+ *   SPDX-FileCopyrightText: 2016 Kai Uwe Broulik <kde@privat.broulik.de>
+ *
+ *   SPDX-License-Identifier: GPL-2.0-or-later
+ */
 
 import QtQuick
 import org.kde.kirigami as Kirigami
@@ -12,7 +12,10 @@ import org.kde.plasma.plasmoid
 Item {
     id: root
 
-    readonly property int iconWidthDelta: (icon.width - icon.paintedWidth) / 4
+    // Safely retrieve the sibling icon object from the parent loader context
+    readonly property Item targetIcon: parent ? parent.visualIcon : null
+
+    readonly property int iconWidthDelta: targetIcon ? (targetIcon.width - targetIcon.paintedWidth) / 4 : 0
     readonly property bool shiftBadgeDown: (Plasmoid.pluginName === "org.vicko.wavetask") && task.audioStreamIcon !== null
 
     Item {
@@ -24,7 +27,7 @@ Item {
 
             anchors.right: parent.right
             anchors.rightMargin: -offset
-            y: root.shiftBadgeDown ? (icon.height / 2) : 0
+            y: root.shiftBadgeDown && root.targetIcon ? (root.targetIcon.height / 2) : 0
 
             Behavior on y {
                 NumberAnimation { duration: Kirigami.Units.longDuration }
@@ -35,7 +38,6 @@ Item {
             height: badgeRect.height + offset * 2
             radius: badgeRect.radius + offset * 2
 
-            // Badge changes width based on number.
             onWidthChanged: maskShaderSource.scheduleUpdate()
             onVisibleChanged: maskShaderSource.scheduleUpdate()
             onYChanged: maskShaderSource.scheduleUpdate()
@@ -44,7 +46,7 @@ Item {
 
     ShaderEffectSource {
         id: iconShaderSource
-        sourceItem: icon
+        sourceItem: root.targetIcon
         hideSource: GraphicsInfo.api !== GraphicsInfo.Software
     }
 
@@ -65,8 +67,8 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
 
-        width: icon.paintedWidth / 2
-        height: icon.paintedWidth / 2
+        width: root.targetIcon ? root.targetIcon.paintedWidth / 2 : parent.width / 2
+        height: root.targetIcon ? root.targetIcon.paintedWidth / 2 : parent.height / 2
 
         source: iconShaderSource
         mask: maskShaderSource
@@ -82,14 +84,14 @@ Item {
 
         y: {
             const offset = Math.round(Math.max(Kirigami.Units.smallSpacing / 2, badgeMask.width / 32));
-            return offset + (root.shiftBadgeDown ? (icon.height / 2) : 0);
+            return offset + (root.shiftBadgeDown && root.targetIcon ? (root.targetIcon.height / 2) : 0);
         }
 
         Behavior on y {
             NumberAnimation { duration: Kirigami.Units.longDuration }
         }
 
-        height: Math.round((icon.height/2) * 0.45)
+        height: root.targetIcon ? Math.round((root.targetIcon.height / 2) * 0.45) : 16
         visible: task.smartLauncherItem.countVisible
         number: task.smartLauncherItem.count
     }

--- a/package/contents/ui/TaskBadgeOverlay.qml
+++ b/package/contents/ui/TaskBadgeOverlay.qml
@@ -1,9 +1,3 @@
-/*
- *   SPDX-FileCopyrightText: 2016 Kai Uwe Broulik <kde@privat.broulik.de>
- *
- *   SPDX-License-Identifier: GPL-2.0-or-later
- */
-
 import QtQuick
 import org.kde.kirigami as Kirigami
 import org.kde.graphicaleffects as KGraphicalEffects
@@ -11,88 +5,57 @@ import org.kde.plasma.plasmoid
 
 Item {
     id: root
+    enabled: false
 
-    // Safely retrieve the sibling icon object from the parent loader context
-    readonly property Item targetIcon: parent ? parent.visualIcon : null
-
-    readonly property int iconWidthDelta: targetIcon ? (targetIcon.width - targetIcon.paintedWidth) / 4 : 0
+    // Reflection Logic
+    readonly property bool reflectionEnabled: Plasmoid.configuration.showReflection || false
+    readonly property int reflectionOffset: reflectionEnabled ? -8 : 0
     readonly property bool shiftBadgeDown: (Plasmoid.pluginName === "org.vicko.wavetask") && task.audioStreamIcon !== null
 
+    // 1. THIS REMAINS VISIBLE: The actual icon sits here
+    // No ShaderEffectSource needed for the main icon.
+
+    // 2. THE BADGE MASK: Only defines the area for the badge
     Item {
         id: badgeMask
         anchors.fill: parent
 
         Rectangle {
-            readonly property int offset: Math.round(Math.max(Kirigami.Units.smallSpacing / 2, badgeMask.width / 32))
-
+            id: maskRect
             anchors.right: parent.right
-            anchors.rightMargin: -offset
-            y: root.shiftBadgeDown && root.targetIcon ? (root.targetIcon.height / 2) : 0
-
-            Behavior on y {
-                NumberAnimation { duration: Kirigami.Units.longDuration }
-            }
-
-            visible: task.smartLauncherItem.countVisible
-            width: badgeRect.width + offset * 2
-            height: badgeRect.height + offset * 2
-            radius: badgeRect.radius + offset * 2
-
-            onWidthChanged: maskShaderSource.scheduleUpdate()
-            onVisibleChanged: maskShaderSource.scheduleUpdate()
-            onYChanged: maskShaderSource.scheduleUpdate()
+            anchors.rightMargin: -Math.round(icon.width * 0.15)
+            y: (root.shiftBadgeDown ? (icon.height / 2) : -Math.round(icon.height * 0.10)) + root.reflectionOffset
+            width: Math.round(icon.width * 0.38)
+            height: Math.round(icon.height * 0.38)
+            radius: width / 2
         }
     }
 
-    ShaderEffectSource {
-        id: iconShaderSource
-        sourceItem: root.targetIcon
-        hideSource: GraphicsInfo.api !== GraphicsInfo.Software
-    }
-
+    // 3. THE SHADER: Only masks the badge area
     ShaderEffectSource {
         id: maskShaderSource
         sourceItem: badgeMask
         hideSource: true
-        live: false
+        live: true
     }
 
     KGraphicalEffects.BadgeEffect {
         id: shader
-
-        anchors.top: parent.top
-        anchors.topMargin: (Kirigami.Units.smallSpacing * 0.7)
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: (Kirigami.Units.smallSpacing * 0.7)
-        anchors.left: parent.left
-        anchors.right: parent.right
-
-        width: root.targetIcon ? root.targetIcon.paintedWidth / 2 : parent.width / 2
-        height: root.targetIcon ? root.targetIcon.paintedWidth / 2 : parent.height / 2
-
-        source: iconShaderSource
+        anchors.fill: parent // Fill parent to encompass the badge area
+        source: icon // Use the icon as the source for the shadow
         mask: maskShaderSource
-
-        onWidthChanged: maskShaderSource.scheduleUpdate()
-        onHeightChanged: maskShaderSource.scheduleUpdate()
     }
 
+    // 4. THE VISUAL BADGE: Rendered on top
     Badge {
         id: badgeRect
-
         anchors.right: parent.right
+        anchors.rightMargin: -Math.round(icon.width * 0.15)
+        y: (root.shiftBadgeDown ? (icon.height / 2) : -Math.round(icon.height * 0.10)) + root.reflectionOffset
 
-        y: {
-            const offset = Math.round(Math.max(Kirigami.Units.smallSpacing / 2, badgeMask.width / 32));
-            return offset + (root.shiftBadgeDown && root.targetIcon ? (root.targetIcon.height / 2) : 0);
-        }
-
-        Behavior on y {
-            NumberAnimation { duration: Kirigami.Units.longDuration }
-        }
-
-        height: root.targetIcon ? Math.round((root.targetIcon.height / 2) * 0.45) : 16
-        visible: task.smartLauncherItem.countVisible
+        scale: 0.5
+        height: Math.round(icon.height * 0.38)
         number: task.smartLauncherItem.count
+        visible: task.smartLauncherItem.countVisible
     }
 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -47,8 +47,7 @@ PlasmoidItem {
     property alias taskRepeater: taskRepeater
 
     readonly property bool metaKeyHeld: backend.metaKeyHeld
-    readonly property bool metaFeaturesEnabled: Plasmoid.configuration.showOnMetaKey
-    || Plasmoid.configuration.showTaskNumbersOnMeta
+    readonly property bool metaFeaturesEnabled: Plasmoid.configuration.showOnMetaKey || Plasmoid.configuration.showTaskNumbersOnMeta
 
     // --- META KEY DOCK VISIBILITY ---
     property bool metaShowActive: false
@@ -93,8 +92,6 @@ PlasmoidItem {
 
     preferredRepresentation: fullRepresentation
 
-    //  Plasmoid.constraintHints: Plasmoid.CanFillArea
-
     // --- LÓGICA DE TRANSPARENCIA ---
     property Item containmentItem: null
     readonly property int depth: 14
@@ -102,13 +99,11 @@ PlasmoidItem {
 
     function lookForContainer(object, tries) {
         if (tries === 0 || object === null) return;
-        // busca el panel
         if (object.toString().indexOf("ContainmentItem_QML") > -1) {
             tasks.containmentItem = object;
             console.log("Contenedor encontrado en el intento: " + (depth - tries));
             console.log("containment width:", tasks.containmentItem.width)
             console.log("containment height:", tasks.containmentItem.height)
-
         } else {
             lookForContainer(object.parent, tries - 1);
         }
@@ -118,10 +113,7 @@ PlasmoidItem {
         if (tasks.containmentItem === null) lookForContainer(tasks.parent, depth);
         if (tasks.containmentItem === null) return;
 
-        // Aplicamos el NoBackground (0) o Default (1)
         tasks.containmentItem.Plasmoid.backgroundHints = (isBackgroundDisabled) ? 0 : 1;
-
-        // También lo aplicamos al objeto raíz por si acaso
         tasks.Plasmoid.backgroundHints = (isBackgroundDisabled) ? 0 : 1;
     }
 
@@ -136,16 +128,13 @@ PlasmoidItem {
     function loadSkinConfig() {
         let skinName = Plasmoid.configuration.skinName || "Default Plasma";
 
-        // LIMPIAR BLUR ANTES DE CAMBIAR
         if (tasks.backend && tasks.parent && tasks.Window && tasks.Window.window) {
             backend.setBlurBehind(tasks.Window.window, false, 0, 0, 0, 0, 0);
             tasks.Window.window.requestUpdate();
             console.log("Blur limpiado antes de aplicar nuevo skin");
         }
 
-        // Construimos la ruta al nuevo archivo Config.qml
         let configUrl = Qt.resolvedUrl("../skins/" + skinName + "/Config.qml");
-
         console.log("Cargando configuración de skin desde: " + configUrl);
 
         let component = Qt.createComponent(configUrl);
@@ -157,12 +146,11 @@ PlasmoidItem {
         }
 
         if (component.status === Component.Ready) {
-            let config = component.createObject(tasks); // 'tasks' es el id de tu PlasmoidItem
+            let config = component.createObject(tasks);
 
             if (config) {
                 let skinFolderUrl = Qt.resolvedUrl("../skins/" + skinName + "/").toString();
 
-                // Actualizamos skinParams de forma reactiva
                 tasks.skinParams = {
                     imageTop: skinFolderUrl + config.imageTop,
                     imageBottom: skinFolderUrl + config.imageBottom,
@@ -172,7 +160,7 @@ PlasmoidItem {
                     imagetask: skinFolderUrl + config.imagetask,
                     blur: config.blur,
                     blurRadius: config.blurRadius,
-                    positionTaskIndicator: config.positionTaskIndicator,
+                    positionTaskIndicator: config.positionTaskIndicator || 9,
                     left: config.leftMargin,
                     top: config.topMargin,
                     right: config.rightMargin,
@@ -184,21 +172,16 @@ PlasmoidItem {
                 };
 
                 console.log("EXITO: Skin '" + skinName + "' cargada. Imagen: " + tasks.skinParams.image);
-
-                // Limpiamos el objeto temporal de memoria
                 config.destroy();
             }
         } else {
             console.log("ERROR al cargar Config.qml: " + component.errorString());
-            // Fallback: Si no existe el .qml, podrías intentar cargar valores por defecto aquí
         }
     }
 
-    // Detecta si entra zoom y si sale
     readonly property bool isZoomActive: {
         for (let i = 0; i < taskRepeater.count; ++i) {
             let item = taskRepeater.itemAt(i);
-            // Si el zoomFactor es mayor a 1.0 (o un umbral mínimo como 1.01)
             if (item && item.zoomFactor > 1.01) return true;
         }
         return false;
@@ -214,40 +197,29 @@ PlasmoidItem {
     Layout.fillHeight: !vertical ? true : Plasmoid.configuration.fill
     Layout.minimumWidth: {
         if (shouldShrinkToZero) {
-            return Kirigami.Units.gridUnit; // For edit mode
+            return Kirigami.Units.gridUnit;
         }
         return vertical ? 0 : LayoutMetrics.preferredMinWidth();
     }
     Layout.minimumHeight: {
         if (shouldShrinkToZero) {
-            return Kirigami.Units.gridUnit; // For edit mode
+            return Kirigami.Units.gridUnit;
         }
         return !vertical ? 0 : LayoutMetrics.preferredMinHeight();
     }
 
-    //BEGIN TODO: this is not precise enough: launchers are smaller than full tasks
     Layout.preferredWidth: {
-        if (shouldShrinkToZero) {
-            return 0.01;
-        }
-        if (vertical) {
-            return Kirigami.Units.gridUnit * 10;
-        }
-        return taskList.Layout.maximumWidth
+        if (shouldShrinkToZero) return 0.01;
+        if (vertical) return Kirigami.Units.gridUnit * 10;
+        return taskList.Layout.maximumWidth;
     }
     Layout.preferredHeight: {
-        if (shouldShrinkToZero) {
-            return 0.01;
-        }
-        if (vertical) {
-            return taskList.Layout.maximumHeight
-        }
+        if (shouldShrinkToZero) return 0.01;
+        if (vertical) return taskList.Layout.maximumHeight;
         return Kirigami.Units.gridUnit * 2;
     }
-    //END TODO
 
     property Item dragSource
-
     signal requestLayout
 
     onDragSourceChanged: {
@@ -257,9 +229,7 @@ PlasmoidItem {
     }
 
     function windowsHovered(winIds: var, hovered: bool): DBus.DBusPendingReply {
-        if (!Plasmoid.configuration.highlightWindows) {
-            return;
-        }
+        if (!Plasmoid.configuration.highlightWindows) return null;
         return DBus.SessionBus.asyncCall({service: "org.kde.KWin.HighlightWindow", path: "/org/kde/KWin/HighlightWindow", iface: "org.kde.KWin.HighlightWindow", member: "highlightWindows", arguments: [hovered ? winIds : []], signature: "(as)"});
     }
 
@@ -268,23 +238,17 @@ PlasmoidItem {
     }
 
     function activateWindowView(winIds: var): DBus.DBusPendingReply {
-        if (!effectWatcher.registered) {
-            return;
-        }
+        if (!effectWatcher.registered) return null;
         cancelHighlightWindows();
         return DBus.SessionBus.asyncCall({service: "org.kde.KWin.Effect.WindowView1", path: "/org/kde/KWin/Effect/WindowView1", iface: "org.kde.KWin.Effect.WindowView1", member: "activate", arguments: [winIds.map(s => String(s))], signature: "(as)"});
     }
 
-    function publishIconGeometries(taskItems: /*list<Item>*/var): void {
-        if (TaskTools.taskManagerInstanceCount >= 2) {
-            return;
-        }
+    function publishIconGeometries(taskItems: var): void {
+        if (TaskTools.taskManagerInstanceCount >= 2) return;
         for (let i = 0; i < taskItems.length - 1; ++i) {
             const task = taskItems[i];
-
-            if (!task.model.IsLauncher && !task.model.IsStartup) {
-                tasksModel.requestPublishDelegateGeometry(tasksModel.makeModelIndex(task.index),
-                                                          backend.globalRect(task), task);
+            if (task && !task.model.IsLauncher && !task.model.IsStartup) {
+                tasksModel.requestPublishDelegateGeometry(tasksModel.makeModelIndex(task.index), backend.globalRect(task), task);
             }
         }
     }
@@ -293,22 +257,14 @@ PlasmoidItem {
         id: tasksModel
 
         readonly property int logicalLauncherCount: {
-            if (Plasmoid.configuration.separateLaunchers) {
-                return launcherCount;
-            }
-
+            if (Plasmoid.configuration.separateLaunchers) return launcherCount;
             let startupsWithLaunchers = 0;
-
             for (let i = 0; i < taskRepeater.count; ++i) {
                 const item = taskRepeater.itemAt(i) as Task;
-
-                // During destruction required properties such as item.model can go null for a while,
-                // so in paths that can trigger on those moments, they need to be guarded
                 if (item?.model?.IsStartup && item.model.HasLauncher) {
                     ++startupsWithLaunchers;
                 }
             }
-
             return launcherCount + startupsWithLaunchers;
         }
 
@@ -324,58 +280,33 @@ PlasmoidItem {
         hideActivatedLaunchers: tasks.iconsOnly || Plasmoid.configuration.hideLauncherOnStart
         sortMode: sortModeEnumValue(Plasmoid.configuration.sortingStrategy)
         launchInPlace: tasks.iconsOnly && Plasmoid.configuration.sortingStrategy === 1
-        separateLaunchers: {
-            if (!tasks.iconsOnly && !Plasmoid.configuration.separateLaunchers
-                && Plasmoid.configuration.sortingStrategy === 1) {
-                return false;
-                }
-
-                return true;
-        }
+        separateLaunchers: (!tasks.iconsOnly && !Plasmoid.configuration.separateLaunchers && Plasmoid.configuration.sortingStrategy === 1) ? false : true
 
         groupMode: groupModeEnumValue(Plasmoid.configuration.groupingStrategy)
         groupInline: !Plasmoid.configuration.groupPopups && !tasks.iconsOnly
-        groupingWindowTasksThreshold: (Plasmoid.configuration.onlyGroupWhenFull && !tasks.iconsOnly
-        ? LayoutMetrics.optimumCapacity(tasks.width, tasks.height) + 1 : -1)
+        groupingWindowTasksThreshold: (Plasmoid.configuration.onlyGroupWhenFull && !tasks.iconsOnly ? LayoutMetrics.optimumCapacity(tasks.width, tasks.height) + 1 : -1)
 
-        onLauncherListChanged: {
-            Plasmoid.configuration.launchers = launcherList;
-        }
+        onLauncherListChanged: Plasmoid.configuration.launchers = launcherList
+        onGroupingAppIdBlacklistChanged: Plasmoid.configuration.groupingAppIdBlacklist = groupingAppIdBlacklist
+        onGroupingLauncherUrlBlacklistChanged: Plasmoid.configuration.groupingLauncherUrlBlacklist = groupingLauncherUrlBlacklist
 
-        onGroupingAppIdBlacklistChanged: {
-            Plasmoid.configuration.groupingAppIdBlacklist = groupingAppIdBlacklist;
-        }
-
-        onGroupingLauncherUrlBlacklistChanged: {
-            Plasmoid.configuration.groupingLauncherUrlBlacklist = groupingLauncherUrlBlacklist;
-        }
-
-        function sortModeEnumValue(index: int): /*TaskManager.TasksModel.SortMode*/ int {
+        function sortModeEnumValue(index: int): int {
             switch (index) {
-                case 0:
-                    return TaskManager.TasksModel.SortDisabled;
-                case 1:
-                    return TaskManager.TasksModel.SortManual;
-                case 2:
-                    return TaskManager.TasksModel.SortAlpha;
-                case 3:
-                    return TaskManager.TasksModel.SortVirtualDesktop;
-                case 4:
-                    return TaskManager.TasksModel.SortActivity;
-                    // 5 is SortLastActivated, skipped
-                case 6:
-                    return TaskManager.TasksModel.SortWindowPositionHorizontal;
-                default:
-                    return TaskManager.TasksModel.SortDisabled;
+                case 0: return TaskManager.TasksModel.SortDisabled;
+                case 1: return TaskManager.TasksModel.SortManual;
+                case 2: return TaskManager.TasksModel.SortAlpha;
+                case 3: return TaskManager.TasksModel.SortVirtualDesktop;
+                case 4: return TaskManager.TasksModel.SortActivity;
+                case 6: return TaskManager.TasksModel.SortWindowPositionHorizontal;
+                default: return TaskManager.TasksModel.SortDisabled;
             }
         }
 
-        function groupModeEnumValue(index: int): /*TaskManager.TasksModel.GroupMode*/ int {
+        function groupModeEnumValue(index: int): int {
             switch (index) {
-                case 0:
-                    return TaskManager.TasksModel.GroupDisabled;
-                case 1:
-                    return TaskManager.TasksModel.GroupApplications;
+                case 0: return TaskManager.TasksModel.GroupDisabled;
+                case 1: return TaskManager.TasksModel.GroupApplications;
+                default: return TaskManager.TasksModel.GroupDisabled;
             }
         }
 
@@ -383,18 +314,13 @@ PlasmoidItem {
             launcherList = Plasmoid.configuration.launchers;
             groupingAppIdBlacklist = Plasmoid.configuration.groupingAppIdBlacklist;
             groupingLauncherUrlBlacklist = Plasmoid.configuration.groupingLauncherUrlBlacklist;
-
-            // Only hook up view only after the above churn is done.
             taskRepeater.model = tasksModel;
         }
     }
 
     readonly property TaskManagerApplet.Backend backend: TaskManagerApplet.Backend {
         id: backend
-
-        onAddLauncher: url => {
-            tasks.addLauncher(url);
-        }
+        onAddLauncher: url => tasks.addLauncher(url)
     }
 
     DBus.DBusServiceWatcher {
@@ -407,7 +333,6 @@ PlasmoidItem {
         Timer {
             interval: 200
             running: true
-
             onTriggered: {
                 const task = parent as Task;
                 if (task) {
@@ -420,28 +345,14 @@ PlasmoidItem {
 
     Connections {
         target: Plasmoid
-
         function onLocationChanged(): void {
-            if (TaskTools.taskManagerInstanceCount >= 2) {
-                return;
-            }
-            // This is on a timer because the panel may not have
-            // settled into position yet when the location prop-
-            // erty updates.
-            console.log(
-                "location=", Plasmoid.location,
-                "tasks.width=", tasks.width,
-                "tasks.height=", tasks.height,
-                "taskList.height=", taskList.height,
-                "centerOffset=", taskList.centerOffset
-            );
+            if (TaskTools.taskManagerInstanceCount >= 2) return;
             iconGeometryTimer.start();
         }
     }
 
     Connections {
         target: Plasmoid.containment
-
         function onScreenGeometryChanged(): void {
             iconGeometryTimer.start();
         }
@@ -454,7 +365,6 @@ PlasmoidItem {
     Item {
         anchors.fill: parent
 
-        // Pushes everything down slightly when docked at the absolute bottom
         transform: Translate {
             y: (Plasmoid.location === PlasmaCore.Types.BottomEdge) ? 12 : 0
         }
@@ -465,7 +375,6 @@ PlasmoidItem {
 
         TaskManager.ActivityInfo {
             id: activityInfo
-            readonly property string nullUuid: "00000000-0000-0000-0000-000000000000"
         }
 
         Loader {
@@ -476,25 +385,17 @@ PlasmoidItem {
 
         Timer {
             id: iconGeometryTimer
-
             interval: 500
             repeat: false
-
-            onTriggered: {
-                tasks.publishIconGeometries(taskList.children, tasks);
-            }
+            onTriggered: tasks.publishIconGeometries(taskList.children)
         }
 
         Binding {
             target: Plasmoid
             property: "status"
             value: {
-                if (tasks.metaShowActive) {
-                    return PlasmaCore.Types.NeedsAttentionStatus;
-                }
-                if (tasksModel.anyTaskDemandsAttention && Plasmoid.configuration.unhideOnAttention) {
-                    return PlasmaCore.Types.NeedsAttentionStatus;
-                }
+                if (tasks.metaShowActive) return PlasmaCore.Types.NeedsAttentionStatus;
+                if (tasksModel.anyTaskDemandsAttention && Plasmoid.configuration.unhideOnAttention) return PlasmaCore.Types.NeedsAttentionStatus;
                 return PlasmaCore.Types.PassiveStatus;
             }
             restoreMode: Binding.RestoreBinding
@@ -502,25 +403,11 @@ PlasmoidItem {
 
         Connections {
             target: Plasmoid.configuration
-
-            function onSkinNameChanged() {
-                console.log("Nueva skin detectada: " + Plasmoid.configuration.skinName);
-                loadSkinConfig(); // La función que lee el .ini y carga la imagen
-            }
-
-            function onIconSizeChanged() {
-                loadSkinConfig();
-            }
-
-            function onLaunchersChanged(): void {
-                tasksModel.launcherList = Plasmoid.configuration.launchers
-            }
-            function onGroupingAppIdBlacklistChanged(): void {
-                tasksModel.groupingAppIdBlacklist = Plasmoid.configuration.groupingAppIdBlacklist;
-            }
-            function onGroupingLauncherUrlBlacklistChanged(): void {
-                tasksModel.groupingLauncherUrlBlacklist = Plasmoid.configuration.groupingLauncherUrlBlacklist;
-            }
+            function onSkinNameChanged() { loadSkinConfig(); }
+            function onIconSizeChanged() { loadSkinConfig(); }
+            function onLaunchersChanged(): void { tasksModel.launcherList = Plasmoid.configuration.launchers; }
+            function onGroupingAppIdBlacklistChanged(): void { tasksModel.groupingAppIdBlacklist = Plasmoid.configuration.groupingAppIdBlacklist; }
+            function onGroupingLauncherUrlBlacklistChanged(): void { tasksModel.groupingLauncherUrlBlacklist = Plasmoid.configuration.groupingLauncherUrlBlacklist; }
         }
 
         Component {
@@ -528,230 +415,96 @@ PlasmoidItem {
             PlasmaComponents3.BusyIndicator {}
         }
 
-        // Save drag data
         Item {
             id: dragHelper
-
             Drag.dragType: Drag.Automatic
             Drag.supportedActions: Qt.CopyAction | Qt.MoveAction | Qt.LinkAction
-            Drag.onDragFinished: dropAction => {
-                tasks.dragSource = null;
-            }
+            Drag.onDragFinished: dropAction => { tasks.dragSource = null; }
         }
 
         KSvg.FrameSvgItem {
             id: taskFrame
-
             visible: false
-
             imagePath: tasks.skinParams.imagetask
             prefix: TaskTools.taskPrefix("normal", Plasmoid.location)
         }
 
         MouseHandler {
             id: mouseHandler
-
             anchors.fill: parent
-
             target: taskList
-
             onUrlsDropped: urls => {
-                // If all dropped URLs point to application desktop files, we'll add a launcher for each of them.
                 const createLaunchers = urls.every(item => tasks.backend.isApplication(item));
-
                 if (createLaunchers) {
                     urls.forEach(item => addLauncher(item));
                     return;
                 }
-
-                if (!hoveredItem) {
-                    return;
-                }
-
-                // Otherwise we'll just start a new instance of the application with the URLs as argument,
-                // as you probably don't expect some of your files to open in the app and others to spawn launchers.
+                if (!hoveredItem) return;
                 tasksModel.requestOpenUrls((hoveredItem as Task).modelIndex(), urls);
             }
         }
 
-        ToolTipDelegate {
-            id: openWindowToolTipDelegate
-            visible: false
-        }
-
-        ToolTipDelegate {
-            id: pinnedAppToolTipDelegate
-            visible: false
-        }
+        ToolTipDelegate { id: openWindowToolTipDelegate; visible: false }
+        ToolTipDelegate { id: pinnedAppToolTipDelegate; visible: false }
 
         Loader {
             id: backgroundLoader
-
             anchors.fill: parent
             sourceComponent: (Plasmoid.configuration.skinName === "Default Plasma") ? defaultSkin : customSkin
         }
 
-        // --- Componente 1: DEFAULT (SVG) ---
         Component {
             id: defaultSkin
             Item {
                 id: internalCanvas
-
                 readonly property bool vertical: tasks.vertical
-
-                readonly property real horizontalMargins:
-                shadowItem.margins.left + shadowItem.margins.right
-
-                readonly property real verticalMargins:
-                shadowItem.margins.top + shadowItem.margins.bottom
-
-                readonly property real baseIconsSize:
-                taskRepeater.count * Plasmoid.configuration.iconSize +
-                Math.max(0, taskRepeater.count - 1) * taskList.spacing
-
-                readonly property real verticalOffsetX: -Kirigami.Units.smallSpacing * 0.5
-
-
-                readonly property real currentGrowth:
-                Math.max(
-                    0,
-                    (taskList.iconsTotalSize + taskList.spacing * 2)
-                    - baseIconsSize
-                ) / 2
-
-                readonly property real panelThickness:
-                Plasmoid.configuration.iconSize * 1.20
+                readonly property real horizontalMargins: shadowItem.margins.left + shadowItem.margins.right
+                readonly property real verticalMargins: shadowItem.margins.top + shadowItem.margins.bottom
+                readonly property real baseIconsSize: taskRepeater.count * Plasmoid.configuration.iconSize + Math.max(0, taskRepeater.count - 1) * taskList.spacing
+                readonly property real currentGrowth: Math.max(0, (taskList.iconsTotalSize + taskList.spacing * 2) - baseIconsSize) / 2
+                readonly property real panelThickness: Plasmoid.configuration.iconSize * 1.20
 
                 KSvg.FrameSvgItem {
                     id: shadowItem
-
                     imagePath: "widgets/panel-background"
                     prefix: "shadow"
-
                     z: -2
-
-                    width: vertical
-                    ? panelThickness + verticalMargins
-                    : horizontalMargins + baseIconsSize + (currentGrowth * 2) + Kirigami.Units.smallSpacing * 2
-
-
-                    height: vertical
-                    ? baseIconsSize + (currentGrowth * 2) + verticalMargins
-                    : panelThickness + verticalMargins + Kirigami.Units.smallSpacing * 0.2
-
-                    x: {
-                        if (!vertical)
-                            return (parent.width - width) / 2;
-
-                        if (vertical && Plasmoid.location === PlasmaCore.Types.RightEdge)
-                            return (taskList.width - width) - Kirigami.Units.smallSpacing * 0.8;
-
-                        return - (verticalMargins/2 + Kirigami.Units.smallSpacing * 0.9);
-                    }
-
-
-                    y: {
-                        if (vertical)
-                            return (parent.height - height) / 2;
-
-                        // Panel arriba
-                        if (tasks.isTopPanel)
-                            return - ((verticalMargins / 2) + Kirigami.Units.smallSpacing * 0.8);
-
-                        // Panel abajo
-                        return (taskList.height - height + (verticalMargins / 2)) + Kirigami.Units.smallSpacing * 0.6;
-                    }
+                    width: vertical ? panelThickness + verticalMargins : horizontalMargins + baseIconsSize + (currentGrowth * 2) + Kirigami.Units.smallSpacing * 2
+                    height: vertical ? baseIconsSize + (currentGrowth * 2) + verticalMargins : panelThickness + verticalMargins + Kirigami.Units.smallSpacing * 0.2
+                    x: !vertical ? (parent.width - width) / 2 : (Plasmoid.location === PlasmaCore.Types.RightEdge ? (taskList.width - width) - Kirigami.Units.smallSpacing * 0.8 : - (verticalMargins/2 + Kirigami.Units.smallSpacing * 0.9))
+                    y: vertical ? (parent.height - height) / 2 : (tasks.isTopPanel ? - ((verticalMargins / 2) + Kirigami.Units.smallSpacing * 0.8) : (taskList.height - height + (verticalMargins / 2)) + Kirigami.Units.smallSpacing * 0.6)
                 }
 
                 KSvg.FrameSvgItem {
                     id: backgroundItem
-
                     imagePath: "widgets/panel-background"
                     prefix: ""
-
                     z: -1
+                    width: vertical ? panelThickness : baseIconsSize + (currentGrowth * 2) + Kirigami.Units.smallSpacing * 2
+                    height: vertical ? baseIconsSize + (currentGrowth * 2) : panelThickness + Kirigami.Units.smallSpacing * 0.2
+                    x: !vertical ? (parent.width - width) / 2 : (Plasmoid.location === PlasmaCore.Types.RightEdge ? taskList.width - width - (verticalMargins / 2) - Kirigami.Units.smallSpacing * 0.8 : - (Kirigami.Units.smallSpacing * 0.9 ))
+                    y: vertical ? (parent.height - height) / 2 : (tasks.isTopPanel ? - Kirigami.Units.smallSpacing * 0.8 : (taskList.height - height) + Kirigami.Units.smallSpacing * 0.6)
 
-                    width: vertical
-                    ? panelThickness
-                    : baseIconsSize + (currentGrowth * 2) + Kirigami.Units.smallSpacing * 2
-
-                    height: vertical
-                    ? baseIconsSize + (currentGrowth * 2)
-                    : panelThickness + Kirigami.Units.smallSpacing * 0.2
-
-                    x: {
-                        if (!vertical)
-                            return (parent.width - width) / 2;
-
-                        if (vertical && Plasmoid.location === PlasmaCore.Types.RightEdge)
-                            return taskList.width - width - (verticalMargins / 2) - Kirigami.Units.smallSpacing * 0.8;
-
-                        return - (Kirigami.Units.smallSpacing * 0.9 );
-                    }
-
-                    y: {
-                        if (vertical)
-                            return (parent.height - height) / 2;
-
-                        // Panel arriba
-                        if (tasks.isTopPanel)
-                            return - Kirigami.Units.smallSpacing * 0.8;
-
-                        // Panel abajo
-                        return (taskList.height - height) + Kirigami.Units.smallSpacing * 0.6;
-                    }
-
-                    readonly property int blurRadius:
-                    tasks.skinParams.blurRadius || 18
-
+                    readonly property int blurRadius: tasks.skinParams.blurRadius || 18
                     function updateBlur() {
-
-                        if (!tasks.skinParams.blur)
-                            return;
-
+                        if (!tasks.skinParams.blur) return;
                         const win = backgroundItem?.Window?.window;
-
-                        if (!win)
-                            return;
-
-                        if (typeof win.visible !== "undefined" && !win.visible)
-                            return;
-
+                        if (!win || (typeof win.visible !== "undefined" && !win.visible)) return;
                         var pos = mapToItem(null, 0, 0);
-
-                        backend.setBlurBehind(
-                            win,
-                            true,
-                            pos.x,
-                            pos.y,
-                            width,
-                            height,
-                            blurRadius
-                        );
-
-                        if (win.requestUpdate)
-                            win.requestUpdate();
+                        backend.setBlurBehind(win, true, pos.x, pos.y, width, height, blurRadius);
+                        if (win.requestUpdate) win.requestUpdate();
                     }
-
-                    function scheduleBlurUpdate() {
-                        Qt.callLater(updateBlur)
-                    }
-
+                    function scheduleBlurUpdate() { Qt.callLater(updateBlur) }
                     onWidthChanged: scheduleBlurUpdate()
                     onHeightChanged: scheduleBlurUpdate()
                     onXChanged: scheduleBlurUpdate()
                     onYChanged: scheduleBlurUpdate()
                     onWindowChanged: scheduleBlurUpdate()
-
-                    onVisibleChanged: {
-                        if (visible)
-                            scheduleBlurUpdate()
-                    }
+                    onVisibleChanged: { if (visible) scheduleBlurUpdate() }
                 }
             }
         }
 
-        // --- Componente 2: CUSTOM SKIN ---
         Component {
             id: customSkin
             BorderImage {
@@ -762,156 +515,51 @@ PlasmoidItem {
                 visible: source.toString() !== ""
                 opacity: 1.0
                 readonly property real spacing: Kirigami.Units.largeSpacing
-                readonly property real topMarginSkin: tasks.containmentItem.height - 76
-                readonly property real leftMarginSkin: tasks.containmentItem.width - 76
+                readonly property real topMarginSkin: tasks.containmentItem ? tasks.containmentItem.height - 76 : 0
+                readonly property real leftMarginSkin: tasks.containmentItem ? tasks.containmentItem.width - 76 : 0
+                property real rightPanelOffset: (tasks.vertical && !tasks.isLeftPanel && tasks.containmentItem) ? ((tasks.containmentItem.width / 2) + Kirigami.Units.smallSpacing * 3) : 0
+                readonly property real currentGrowth: Math.max(0, taskList.maxZoom + spacing * 8) / 2
 
-                property real rightPanelOffset:(tasks.vertical && !tasks.isLeftPanel) ? ((tasks.containmentItem.width / 2) + Kirigami.Units.smallSpacing * 3) : 0
-
-                // Cuánto crecieron los iconos con zoom respecto al base
-                readonly property real currentGrowth: Math.max(0, taskList.maxZoom + spacing * 8
-                ) / 2
-
-                property real dynamicLeftMargin: tasks.skinParams.outLeft
-                + taskList.centerOffset
-                - currentGrowth
-
-                property real dynamicRightMargin: tasks.skinParams.outRight
-                + taskList.centerOffset
-                - currentGrowth
+                property real dynamicLeftMargin: (tasks.skinParams.outLeft || 0) + taskList.centerOffset - currentGrowth
+                property real dynamicRightMargin: (tasks.skinParams.outRight || 0) + taskList.centerOffset - currentGrowth
 
                 anchors {
                     fill: parent
-
-                    leftMargin: tasks.vertical
-                    ? (tasks.isLeftPanel
-                    ? (tasks.skinParams.outBottom || 0)
-                    : (tasks.skinParams.outTop + leftMarginSkin || 0)) // <-- CORREGIDO: Se añade aquí para el panel derecho
-                    : (dockBackground.dynamicLeftMargin || 0)
-
-                    rightMargin: tasks.vertical
-                    ? (tasks.isLeftPanel
-                    ? (tasks.skinParams.outTop + leftMarginSkin || 0)
-                    : (tasks.skinParams.outBottom || 0)) // <-- CORREGIDO: Se quita de aquí para el panel derecho
-                    : (dockBackground.dynamicRightMargin || 0)
-
-                    topMargin: tasks.vertical
-                    ? ((tasks.skinParams.outRight || 0)
-                    + taskList.centerOffset
-                    - currentGrowth)
-                    : (tasks.isTopPanel
-                    ? (tasks.skinParams.outBottom || 0)
-                    : (tasks.skinParams.outTop + topMarginSkin || 0))
-
-                    bottomMargin: tasks.vertical
-                    ? ((tasks.skinParams.outLeft || 0)
-                    + taskList.centerOffset
-                    - currentGrowth)
-                    : (tasks.isTopPanel
-                    ? (tasks.skinParams.outTop + topMarginSkin || 0)
-                    : (tasks.skinParams.outBottom || 0))
+                    leftMargin: tasks.vertical ? (tasks.isLeftPanel ? (tasks.skinParams.outBottom || 0) : (tasks.skinParams.outTop + leftMarginSkin || 0)) : (dockBackground.dynamicLeftMargin || 0)
+                    rightMargin: tasks.vertical ? (tasks.isLeftPanel ? (tasks.skinParams.outTop + leftMarginSkin || 0) : (tasks.skinParams.outBottom || 0)) : (dockBackground.dynamicRightMargin || 0)
+                    topMargin: tasks.vertical ? ((tasks.skinParams.outRight || 0) + taskList.centerOffset - currentGrowth) : (tasks.isTopPanel ? (tasks.skinParams.outBottom || 0) : (tasks.skinParams.outTop + topMarginSkin || 0))
+                    bottomMargin: tasks.vertical ? ((tasks.skinParams.outLeft || 0) + taskList.centerOffset - currentGrowth) : (tasks.isTopPanel ? (tasks.skinParams.outTop + topMarginSkin || 0) : (tasks.skinParams.outBottom || 0))
                 }
 
-                source: {
-                    if (tasks.vertical) {
-                        return tasks.isLeftPanel
-                        ? tasks.skinParams.imageLeft
-                        : tasks.skinParams.imageRight;
-                    }
-
-                    return tasks.isTopPanel
-                    ? tasks.skinParams.imageTop
-                    : tasks.skinParams.imageBottom;
-                }
+                source: tasks.vertical ? (tasks.isLeftPanel ? tasks.skinParams.imageLeft : tasks.skinParams.imageRight) : (tasks.isTopPanel ? tasks.skinParams.imageTop : tasks.skinParams.imageBottom)
 
                 border {
-                    left: tasks.vertical
-                    ? (tasks.isLeftPanel
-                    ? tasks.skinParams.bottom
-                    : tasks.skinParams.top)
-                    : tasks.skinParams.left
-
-                    top: tasks.vertical
-                    ? tasks.skinParams.right
-                    : tasks.skinParams.top
-
-                    right: tasks.vertical
-                    ? (tasks.isLeftPanel
-                    ? tasks.skinParams.top
-                    : tasks.skinParams.bottom)
-                    : tasks.skinParams.right
-
-                    bottom: tasks.vertical
-                    ? tasks.skinParams.left
-                    : tasks.skinParams.bottom
+                    left: tasks.vertical ? (tasks.isLeftPanel ? tasks.skinParams.bottom : tasks.skinParams.top) : tasks.skinParams.left
+                    top: tasks.vertical ? tasks.skinParams.right : tasks.skinParams.top
+                    right: tasks.vertical ? (tasks.isLeftPanel ? tasks.skinParams.top : tasks.skinParams.bottom) : tasks.skinParams.right
+                    bottom: tasks.vertical ? tasks.skinParams.left : tasks.skinParams.bottom
                 }
 
                 horizontalTileMode: BorderImage.Stretch
                 verticalTileMode: BorderImage.Stretch
                 z: -1
 
-
-                // --- INTEGRACIÓN DEL BLUR ---
-
-                // Radio de blur
                 readonly property int blurRadius: tasks.skinParams.blurRadius || 24
-
-                // Función centralizada para actualizar el blur
                 function updateBlur() {
-                    if (!tasks.skinParams.blur) {
-                        return;
-                    }
-
+                    if (!tasks.skinParams.blur) return;
                     const win = dockBackground?.Window?.window;
-
-                    if (!win) {
-                        return;
-                    }
-
-                    // opcional: proteger también visible
-                    if (typeof win.visible !== "undefined" && !win.visible) {
-                        return;
-                    }
-
+                    if (!win || (typeof win.visible !== "undefined" && !win.visible)) return;
                     var pos = mapToItem(null, 0, 0);
-
-                    /*    if (tasks.vertical && !tasks.isLeftPanel) {
-                     *                       pos = mapToItem(null, - Kirigami.Units.smallSpacing * 3, 0);
-                } */
-
-                    backend.setBlurBehind(
-                        win,
-                        true,
-                        pos.x,
-                        pos.y,
-                        width,
-                        height,
-                        blurRadius
-                    );
-
-                    if (win.requestUpdate) {
-                        win.requestUpdate();
-                    }
+                    backend.setBlurBehind(win, true, pos.x, pos.y, width, height, blurRadius);
+                    if (win.requestUpdate) win.requestUpdate();
                 }
-
-                // --- CONEXIONES PARA ACTUALIZACIÓN DINÁMICA ---
-
-                // Cuando el componente termina de cargar
-                function scheduleBlurUpdate() {
-                    Qt.callLater(updateBlur)
-                }
-
+                function scheduleBlurUpdate() { Qt.callLater(updateBlur) }
                 onWidthChanged: scheduleBlurUpdate()
                 onHeightChanged: scheduleBlurUpdate()
                 onXChanged: scheduleBlurUpdate()
                 onYChanged: scheduleBlurUpdate()
-
                 onWindowChanged: scheduleBlurUpdate()
-
-                onVisibleChanged: {
-                    if (visible) {
-                        scheduleBlurUpdate()
-                    }
-                }
+                onVisibleChanged: { if (visible) scheduleBlurUpdate() }
             }
         }
 
@@ -920,216 +568,106 @@ PlasmoidItem {
             filterTimeOut: 300
             active: false
             blockFirstEnter: false
-
             edge: {
                 switch (Plasmoid.location) {
-                    case PlasmaCore.Types.BottomEdge:
-                        return Qt.TopEdge;
-                    case PlasmaCore.Types.TopEdge:
-                        return Qt.BottomEdge;
-                    case PlasmaCore.Types.LeftEdge:
-                        return Qt.RightEdge;
-                    case PlasmaCore.Types.RightEdge:
-                        return Qt.LeftEdge;
-                    default:
-                        return Qt.TopEdge;
+                    case PlasmaCore.Types.BottomEdge: return Qt.TopEdge;
+                    case PlasmaCore.Types.TopEdge: return Qt.BottomEdge;
+                    case PlasmaCore.Types.LeftEdge: return Qt.RightEdge;
+                    case PlasmaCore.Types.RightEdge: return Qt.LeftEdge;
+                    default: return Qt.TopEdge;
                 }
             }
-
             LayoutMirroring.enabled: tasks.shouldBeMirrored(Plasmoid.configuration.reverseMode, Application.layoutDirection, tasks.vertical)
-
-            anchors {
-                left: parent.left
-                top: parent.top
-            }
-
+            anchors { left: parent.left; top: parent.top }
             height: taskList.height
             width: taskList.width
 
             TaskList {
                 id: taskList
-
                 property real smoothMouse: -1
                 property bool insideDock: false
-                property alias animating: taskList.animating
                 readonly property real spacing: Kirigami.Units.smallSpacing
                 readonly property real _baseSize: Plasmoid.configuration.iconSize
                 readonly property real _sigma: _baseSize * Plasmoid.configuration.amplitud
-
                 readonly property real totalWidth: tasks.taskRepeater.count * _baseSize
-
                 readonly property real _zoom: (Plasmoid.configuration.magnification || 0) / 100
                 readonly property real maxZoom: 1.0 + (Plasmoid.configuration.magnification || 0) / 100
-
                 readonly property real baseContentSize: taskRepeater.count * Plasmoid.configuration.iconSize + Math.max(0, taskRepeater.count - 1) * spacing
-
-                // Integral gaussiana aproximada
                 readonly property real zoomExtraSize: _zoom * _sigma * Math.sqrt(2 * Math.PI)
-
                 property real contentSize: Math.ceil(baseContentSize + zoomExtraSize + spacing * 4)
 
                 readonly property real iconsTotalSize: {
                     let total = 0;
-
                     for (let i = 0; i < taskRepeater.count; ++i) {
                         let item = taskRepeater.itemAt(i);
-
                         if (item) {
-
-                            total += tasks.vertical
-                            ? item.height
-                            : item.width;
-
-                            if (i > 0)
-                                total += spacing;
+                            total += tasks.vertical ? item.height : item.width;
+                            if (i > 0) total += spacing;
                         }
                     }
-
                     return total;
                 }
 
                 readonly property real centerOffset: {
-                    let availableSize = tasks.vertical
-                    ? height
-                    : width;
-
+                    let availableSize = tasks.vertical ? height : width;
                     return (availableSize - iconsTotalSize) / 2;
                 }
 
                 Layout.maximumWidth: contentSize
                 Layout.maximumHeight: contentSize
+                width: tasks.vertical ? Math.ceil(Plasmoid.configuration.iconSize * taskList.maxZoom + spacing * 4) : contentSize
+                height: tasks.vertical ? contentSize : tasks.height
+                flow: tasks.vertical ? (Plasmoid.configuration.forceStripes ? Grid.LeftToRight : Grid.TopToBottom) : (Plasmoid.configuration.forceStripes ? Grid.TopToBottom : Grid.LeftToRight)
 
-                width: {
-                    if (tasks.vertical) {
-                        return Math.ceil(
-                            Plasmoid.configuration.iconSize *
-                            taskList.maxZoom +
-                            spacing * 4
-                        );
-                    }
-
-                    return contentSize;
-                }
-
-                height: {
-                    if (tasks.vertical) {
-                        return contentSize;
-                    }
-
-                    return tasks.height;
-                }
-
-                flow: {
-                    if (tasks.vertical) {
-                        return Plasmoid.configuration.forceStripes ? Grid.LeftToRight : Grid.TopToBottom
-                    }
-                    return Plasmoid.configuration.forceStripes ? Grid.TopToBottom : Grid.LeftToRight
-                }
-
-                onAnimatingChanged: {
-                    if (!animating) {
-                        tasks.publishIconGeometries(children, tasks);
-                    }
-                }
+                onAnimatingChanged: { if (!animating) tasks.publishIconGeometries(children) }
 
                 HoverHandler {
                     id: dockHoverHandler
-
                     onPointChanged: {
                         let mappedPos = taskList.mapToItem(tasks, point.position.x, point.position.y)
-
                         let mousePos = tasks.vertical ? mappedPos.y : mappedPos.x
-
                         if (taskList.smoothMouse < 0) {
                             taskList.smoothMouse = mousePos
                         } else {
-                            taskList.smoothMouse +=
-                            (mousePos - taskList.smoothMouse) * 0.3
+                            taskList.smoothMouse += (mousePos - taskList.smoothMouse) * 0.3
                         }
-
                         taskList.insideDock = true
                     }
-
-                    onHoveredChanged: {
-                        if (hovered) {
-                            taskList.insideDock = true;
-                        } else {
-                            exitTimer.restart();
-                        }
-                    }
+                    onHoveredChanged: { if (hovered) { taskList.insideDock = true; } else { exitTimer.restart(); } }
                 }
 
                 Timer {
                     id: exitTimer
                     interval: 40
                     repeat: false
-                    onTriggered: {
-                        if (!dockHoverHandler.hovered) {
-                            taskList.insideDock = false;
-                        }
-                    }
+                    onTriggered: { if (!dockHoverHandler.hovered) taskList.insideDock = false; }
                 }
 
                 Repeater {
                     id: taskRepeater
                     model: tasksModel
-
                     delegate: Task {
                         id: taskItem
                         tasksRoot: tasks
                         dockRef: taskList
-
-                        x: {
-                            if (tasks.vertical && tasks.isLeftPanel)
-                                return 0;
-
-                            if (tasks.vertical)
-                                return (parent.width / 2) - (taskList.spacing * 3);
-
-                            return itemPos;
-                        }
-
-                        y: {
-                            if (isTopPanel)
-                                return  0;
-
-                            if (tasks.vertical)
-                                return itemPos;
-
-                            return 0;
-                        }
-
+                        x: tasks.vertical ? (tasks.isLeftPanel ? 0 : (parent.width / 2) - (taskList.spacing * 3)) : itemPos
+                        y: tasks.vertical ? itemPos : 0
                         property real itemPos: {
                             let pos = taskList.centerOffset;
-
                             for (let i = 0; i < index; ++i) {
                                 let previousItem = taskRepeater.itemAt(i);
-
-                                let size = previousItem
-                                ? (tasks.vertical
-                                ? previousItem.height
-                                : previousItem.width)
-                                : Plasmoid.configuration.iconSize;
-
+                                let size = previousItem ? (tasks.vertical ? previousItem.height : previousItem.width) : Plasmoid.configuration.iconSize;
                                 pos += size + taskList.spacing;
                             }
-
                             return pos;
                         }
-
-                        width: tasks.vertical
-                        ? Plasmoid.configuration.iconSize
-                        : (Plasmoid.configuration.iconSize * zoomFactor)
-
-                        height: tasks.vertical
-                        ? (Plasmoid.configuration.iconSize * zoomFactor)
-                        : undefined
+                        width: tasks.vertical ? Plasmoid.configuration.iconSize : (Plasmoid.configuration.iconSize * zoomFactor)
+                        height: tasks.vertical ? (Plasmoid.configuration.iconSize * zoomFactor) : undefined
                     }
                 }
             }
         }
 
-        // Gestiona la vinculación de propiedades una vez que el componente se carga en memoria.
         Loader {
             id: penguinLoader
             active: ((!tasks.vertical) && Plasmoid.configuration.cairoPenguinEnabled)
@@ -1137,14 +675,10 @@ PlasmoidItem {
             anchors.bottom: tasks.isTopPanel ? undefined : parent.bottom
             anchors.top: tasks.isTopPanel ? parent.top : undefined
             anchors.topMargin: tasks.isTopPanel ? Plasmoid.configuration.iconSize / 3 : 0
-
             source: "CairoPenguin.qml"
-
-            // Pasa los enlaces (bindings) al componente cargado
             onLoaded: {
                 let calculateMinX = () => taskList.x + taskList.centerOffset;
                 let calculateMaxX = () => calculateMinX() + taskList.iconsTotalSize - item.width;
-
                 item.minX = Qt.binding(calculateMinX);
                 item.maxX = Qt.binding(calculateMaxX);
             }
@@ -1154,34 +688,14 @@ PlasmoidItem {
         property GroupDialog groupDialog
     }
 
-    readonly property Component groupDialogComponent: Qt.createComponent("GroupDialog.qml")
-    property GroupDialog groupDialog
-
     readonly property bool supportsLaunchers: true
 
-    function hasLauncher(url: url): bool {
-        return tasksModel.launcherPosition(url) !== -1;
-    }
+    function hasLauncher(url: url): bool { return tasksModel.launcherPosition(url) !== -1; }
+    function addLauncher(url: url): void { if (Plasmoid.immutability !== PlasmaCore.Types.SystemImmutable) tasksModel.requestAddLauncher(url); }
+    function removeLauncher(url: url): void { if (Plasmoid.immutability !== PlasmaCore.Types.SystemImmutable) tasksModel.requestRemoveLauncher(url); }
 
-    function addLauncher(url: url): void {
-        if (Plasmoid.immutability !== PlasmaCore.Types.SystemImmutable) {
-            tasksModel.requestAddLauncher(url);
-        }
-    }
-
-    function removeLauncher(url: url): void {
-        if (Plasmoid.immutability !== PlasmaCore.Types.SystemImmutable) {
-            tasksModel.requestRemoveLauncher(url);
-        }
-    }
-
-    // This is called by plasmashell in response to a Meta+number shortcut.
-    // TODO: Change type to int
     function activateTaskAtIndex(index: var): void {
-        if (typeof index !== "number") {
-            return;
-        }
-
+        if (typeof index !== "number") return;
         const task = taskRepeater.itemAt(index) as Task;
         if (task) {
             TaskTools.activateTask(task.modelIndex(), task.model, null, task, Plasmoid, this, effectWatcher.registered);
@@ -1189,56 +703,34 @@ PlasmoidItem {
     }
 
     function createContextMenu(rootTask, modelIndex, args = {}) {
-        const initialArgs = Object.assign(args, {
-            visualParent: rootTask,
-            modelIndex,
-            mpris2Source,
-            backend,
-        });
+        const initialArgs = Object.assign(args, { visualParent: rootTask, modelIndex, mpris2Source, backend });
         return contextMenuComponent.createObject(rootTask, initialArgs);
     }
 
     function shouldBeMirrored(reverseMode, layoutDirection, vertical): bool {
-        // LayoutMirroring is only horizontal
-        if (vertical) {
-            return layoutDirection === Qt.RightToLeft;
-        }
-
-        if (layoutDirection === Qt.LeftToRight) {
-            return reverseMode;
-        }
-        return !reverseMode;
+        if (vertical) return layoutDirection === Qt.RightToLeft;
+        return layoutDirection === Qt.LeftToRight ? reverseMode : !reverseMode;
     }
 
     Component.onCompleted: {
         TaskTools.taskManagerInstanceCount += 1;
         requestLayout.connect(iconGeometryTimer.restart);
         applyBackgroundHint();
-        // --- CARGAR SKIN AL INICIAR ---
         loadSkinConfig();
     }
 
-    Component.onDestruction: {
-        TaskTools.taskManagerInstanceCount -= 1;
-    }
+    Component.onDestruction: { TaskTools.taskManagerInstanceCount -= 1; }
 
-    // para hacer panel transparente
     Timer {
         id: initializeAppletTimer
         interval: 1200
-        repeat: false // Lo hacemos repetir hasta que encuentre el contenedor
+        repeat: false
         running: true
-
         property int step: 0
         readonly property int maxStep: 5
-
         onTriggered: {
-            console.log("Intento de transparencia número: " + (step + 1));
             applyBackgroundHint();
-
-            if (tasks.containmentItem !== null || step >= maxStep) {
-                stop(); // Se detiene cuando lo logra o alcanza el límite
-            }
+            if (tasks.containmentItem !== null || step >= maxStep) stop();
             step++;
         }
     }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -1,8 +1,8 @@
 /*
-    SPDX-FileCopyrightText: 2012-2016 Eike Hein <hein@kde.org>
-
-    SPDX-License-Identifier: GPL-2.0-or-later
-*/
+ *   SPDX-FileCopyrightText: 2012-2016 Eike Hein <hein@kde.org>
+ *
+ *   SPDX-License-Identifier: GPL-2.0-or-later
+ */
 pragma ComponentBehavior: Bound
 
 import QtQuick
@@ -48,7 +48,7 @@ PlasmoidItem {
 
     readonly property bool metaKeyHeld: backend.metaKeyHeld
     readonly property bool metaFeaturesEnabled: Plasmoid.configuration.showOnMetaKey
-                                                || Plasmoid.configuration.showTaskNumbersOnMeta
+    || Plasmoid.configuration.showTaskNumbersOnMeta
 
     // --- META KEY DOCK VISIBILITY ---
     property bool metaShowActive: false
@@ -93,116 +93,116 @@ PlasmoidItem {
 
     preferredRepresentation: fullRepresentation
 
-  //  Plasmoid.constraintHints: Plasmoid.CanFillArea
+    //  Plasmoid.constraintHints: Plasmoid.CanFillArea
 
-  // --- LÓGICA DE TRANSPARENCIA ---
-  property Item containmentItem: null
-  readonly property int depth: 14
-  property bool isBackgroundDisabled: true
+    // --- LÓGICA DE TRANSPARENCIA ---
+    property Item containmentItem: null
+    readonly property int depth: 14
+    property bool isBackgroundDisabled: true
 
-  function lookForContainer(object, tries) {
-      if (tries === 0 || object === null) return;
-      // busca el panel
-      if (object.toString().indexOf("ContainmentItem_QML") > -1) {
-          tasks.containmentItem = object;
-          console.log("Contenedor encontrado en el intento: " + (depth - tries));
-          console.log("containment width:", tasks.containmentItem.width)
-          console.log("containment height:", tasks.containmentItem.height)
+    function lookForContainer(object, tries) {
+        if (tries === 0 || object === null) return;
+        // busca el panel
+        if (object.toString().indexOf("ContainmentItem_QML") > -1) {
+            tasks.containmentItem = object;
+            console.log("Contenedor encontrado en el intento: " + (depth - tries));
+            console.log("containment width:", tasks.containmentItem.width)
+            console.log("containment height:", tasks.containmentItem.height)
 
-      } else {
-          lookForContainer(object.parent, tries - 1);
-      }
-  }
+        } else {
+            lookForContainer(object.parent, tries - 1);
+        }
+    }
 
-  function applyBackgroundHint() {
-      if (tasks.containmentItem === null) lookForContainer(tasks.parent, depth);
-      if (tasks.containmentItem === null) return;
+    function applyBackgroundHint() {
+        if (tasks.containmentItem === null) lookForContainer(tasks.parent, depth);
+        if (tasks.containmentItem === null) return;
 
-      // Aplicamos el NoBackground (0) o Default (1)
-      tasks.containmentItem.Plasmoid.backgroundHints = (isBackgroundDisabled) ? 0 : 1;
+        // Aplicamos el NoBackground (0) o Default (1)
+        tasks.containmentItem.Plasmoid.backgroundHints = (isBackgroundDisabled) ? 0 : 1;
 
-      // También lo aplicamos al objeto raíz por si acaso
-      tasks.Plasmoid.backgroundHints = (isBackgroundDisabled) ? 0 : 1;
-  }
+        // También lo aplicamos al objeto raíz por si acaso
+        tasks.Plasmoid.backgroundHints = (isBackgroundDisabled) ? 0 : 1;
+    }
 
-  // --- LÓGICA DE SKINS ---
-  property int topoutimage: 0
-  property var skinParams: ({
-      imageTop: "", imageBottom: "", imageLeft: "", imageRight: "", imagetask: "", blur: false, blurRadius: 18, positionTaskIndicator: 9,
-      left: 0, top: 0, right: 0, bottom: 0,
-      outLeft: 0, outTop: 0, outRight: 0, outBottom: 0
-  })
+    // --- LÓGICA DE SKINS ---
+    property int topoutimage: 0
+    property var skinParams: ({
+        imageTop: "", imageBottom: "", imageLeft: "", imageRight: "", imagetask: "", blur: false, blurRadius: 18, positionTaskIndicator: 9,
+        left: 0, top: 0, right: 0, bottom: 0,
+        outLeft: 0, outTop: 0, outRight: 0, outBottom: 0
+    })
 
-  function loadSkinConfig() {
-      let skinName = Plasmoid.configuration.skinName || "Default Plasma";
+    function loadSkinConfig() {
+        let skinName = Plasmoid.configuration.skinName || "Default Plasma";
 
-      // LIMPIAR BLUR ANTES DE CAMBIAR
-      if (tasks.backend && tasks.parent && tasks.Window && tasks.Window.window) {
-          backend.setBlurBehind(tasks.Window.window, false, 0, 0, 0, 0, 0);
-          tasks.Window.window.requestUpdate();
-          console.log("Blur limpiado antes de aplicar nuevo skin");
-      }
+        // LIMPIAR BLUR ANTES DE CAMBIAR
+        if (tasks.backend && tasks.parent && tasks.Window && tasks.Window.window) {
+            backend.setBlurBehind(tasks.Window.window, false, 0, 0, 0, 0, 0);
+            tasks.Window.window.requestUpdate();
+            console.log("Blur limpiado antes de aplicar nuevo skin");
+        }
 
-      // Construimos la ruta al nuevo archivo Config.qml
-      let configUrl = Qt.resolvedUrl("../skins/" + skinName + "/Config.qml");
+        // Construimos la ruta al nuevo archivo Config.qml
+        let configUrl = Qt.resolvedUrl("../skins/" + skinName + "/Config.qml");
 
-      console.log("Cargando configuración de skin desde: " + configUrl);
+        console.log("Cargando configuración de skin desde: " + configUrl);
 
-      let component = Qt.createComponent(configUrl);
+        let component = Qt.createComponent(configUrl);
 
-      if (Plasmoid.configuration.iconSize <= 44) {
-          tasks.topoutimage = Math.abs(Plasmoid.configuration.iconSize - 44);
-      } else {
-          tasks.topoutimage = 44 - Plasmoid.configuration.iconSize;
-      }
+        if (Plasmoid.configuration.iconSize <= 44) {
+            tasks.topoutimage = Math.abs(Plasmoid.configuration.iconSize - 44);
+        } else {
+            tasks.topoutimage = 44 - Plasmoid.configuration.iconSize;
+        }
 
-      if (component.status === Component.Ready) {
-          let config = component.createObject(tasks); // 'tasks' es el id de tu PlasmoidItem
+        if (component.status === Component.Ready) {
+            let config = component.createObject(tasks); // 'tasks' es el id de tu PlasmoidItem
 
-          if (config) {
-              let skinFolderUrl = Qt.resolvedUrl("../skins/" + skinName + "/").toString();
+            if (config) {
+                let skinFolderUrl = Qt.resolvedUrl("../skins/" + skinName + "/").toString();
 
-              // Actualizamos skinParams de forma reactiva
-              tasks.skinParams = {
-                  imageTop: skinFolderUrl + config.imageTop,
-                  imageBottom: skinFolderUrl + config.imageBottom,
-                  imageLeft: skinFolderUrl + config.imageLeft,
-                  imageRight: skinFolderUrl + config.imageRight,
-                  image: skinFolderUrl + config.image,
-                  imagetask: skinFolderUrl + config.imagetask,
-                  blur: config.blur,
-                  blurRadius: config.blurRadius,
-                  positionTaskIndicator: config.positionTaskIndicator,
-                  left: config.leftMargin,
-                  top: config.topMargin,
-                  right: config.rightMargin,
-                  bottom: config.bottomMargin,
-                  outLeft: config.outsideLeftMargin,
-                  outTop: config.outsideTopMargin + tasks.topoutimage,
-                  outRight: config.outsideRightMargin,
-                  outBottom: config.outsideBottomMargin
-              };
+                // Actualizamos skinParams de forma reactiva
+                tasks.skinParams = {
+                    imageTop: skinFolderUrl + config.imageTop,
+                    imageBottom: skinFolderUrl + config.imageBottom,
+                    imageLeft: skinFolderUrl + config.imageLeft,
+                    imageRight: skinFolderUrl + config.imageRight,
+                    image: skinFolderUrl + config.image,
+                    imagetask: skinFolderUrl + config.imagetask,
+                    blur: config.blur,
+                    blurRadius: config.blurRadius,
+                    positionTaskIndicator: config.positionTaskIndicator,
+                    left: config.leftMargin,
+                    top: config.topMargin,
+                    right: config.rightMargin,
+                    bottom: config.bottomMargin,
+                    outLeft: config.outsideLeftMargin,
+                    outTop: config.outsideTopMargin + tasks.topoutimage,
+                    outRight: config.outsideRightMargin,
+                    outBottom: config.outsideBottomMargin
+                };
 
-              console.log("EXITO: Skin '" + skinName + "' cargada. Imagen: " + tasks.skinParams.image);
+                console.log("EXITO: Skin '" + skinName + "' cargada. Imagen: " + tasks.skinParams.image);
 
-              // Limpiamos el objeto temporal de memoria
-              config.destroy();
-          }
-      } else {
-          console.log("ERROR al cargar Config.qml: " + component.errorString());
-          // Fallback: Si no existe el .qml, podrías intentar cargar valores por defecto aquí
-      }
-  }
+                // Limpiamos el objeto temporal de memoria
+                config.destroy();
+            }
+        } else {
+            console.log("ERROR al cargar Config.qml: " + component.errorString());
+            // Fallback: Si no existe el .qml, podrías intentar cargar valores por defecto aquí
+        }
+    }
 
-  // Detecta si entra zoom y si sale
-  readonly property bool isZoomActive: {
-      for (let i = 0; i < taskRepeater.count; ++i) {
-          let item = taskRepeater.itemAt(i);
-          // Si el zoomFactor es mayor a 1.0 (o un umbral mínimo como 1.01)
-          if (item && item.zoomFactor > 1.01) return true;
-      }
-      return false;
-  }
+    // Detecta si entra zoom y si sale
+    readonly property bool isZoomActive: {
+        for (let i = 0; i < taskRepeater.count; ++i) {
+            let item = taskRepeater.itemAt(i);
+            // Si el zoomFactor es mayor a 1.0 (o un umbral mínimo como 1.01)
+            if (item && item.zoomFactor > 1.01) return true;
+        }
+        return false;
+    }
 
     Plasmoid.onUserConfiguringChanged: {
         if (Plasmoid.userConfiguring && groupDialog !== null) {
@@ -225,7 +225,7 @@ PlasmoidItem {
         return !vertical ? 0 : LayoutMetrics.preferredMinHeight();
     }
 
-//BEGIN TODO: this is not precise enough: launchers are smaller than full tasks
+    //BEGIN TODO: this is not precise enough: launchers are smaller than full tasks
     Layout.preferredWidth: {
         if (shouldShrinkToZero) {
             return 0.01;
@@ -244,7 +244,7 @@ PlasmoidItem {
         }
         return Kirigami.Units.gridUnit * 2;
     }
-//END TODO
+    //END TODO
 
     property Item dragSource
 
@@ -284,7 +284,7 @@ PlasmoidItem {
 
             if (!task.model.IsLauncher && !task.model.IsStartup) {
                 tasksModel.requestPublishDelegateGeometry(tasksModel.makeModelIndex(task.index),
-                    backend.globalRect(task), task);
+                                                          backend.globalRect(task), task);
             }
         }
     }
@@ -328,15 +328,15 @@ PlasmoidItem {
             if (!tasks.iconsOnly && !Plasmoid.configuration.separateLaunchers
                 && Plasmoid.configuration.sortingStrategy === 1) {
                 return false;
-            }
+                }
 
-            return true;
+                return true;
         }
 
         groupMode: groupModeEnumValue(Plasmoid.configuration.groupingStrategy)
         groupInline: !Plasmoid.configuration.groupPopups && !tasks.iconsOnly
         groupingWindowTasksThreshold: (Plasmoid.configuration.onlyGroupWhenFull && !tasks.iconsOnly
-            ? LayoutMetrics.optimumCapacity(tasks.width, tasks.height) + 1 : -1)
+        ? LayoutMetrics.optimumCapacity(tasks.width, tasks.height) + 1 : -1)
 
         onLauncherListChanged: {
             Plasmoid.configuration.launchers = launcherList;
@@ -352,30 +352,30 @@ PlasmoidItem {
 
         function sortModeEnumValue(index: int): /*TaskManager.TasksModel.SortMode*/ int {
             switch (index) {
-            case 0:
-                return TaskManager.TasksModel.SortDisabled;
-            case 1:
-                return TaskManager.TasksModel.SortManual;
-            case 2:
-                return TaskManager.TasksModel.SortAlpha;
-            case 3:
-                return TaskManager.TasksModel.SortVirtualDesktop;
-            case 4:
-                return TaskManager.TasksModel.SortActivity;
-            // 5 is SortLastActivated, skipped
-            case 6:
-                return TaskManager.TasksModel.SortWindowPositionHorizontal;
-            default:
-                return TaskManager.TasksModel.SortDisabled;
+                case 0:
+                    return TaskManager.TasksModel.SortDisabled;
+                case 1:
+                    return TaskManager.TasksModel.SortManual;
+                case 2:
+                    return TaskManager.TasksModel.SortAlpha;
+                case 3:
+                    return TaskManager.TasksModel.SortVirtualDesktop;
+                case 4:
+                    return TaskManager.TasksModel.SortActivity;
+                    // 5 is SortLastActivated, skipped
+                case 6:
+                    return TaskManager.TasksModel.SortWindowPositionHorizontal;
+                default:
+                    return TaskManager.TasksModel.SortDisabled;
             }
         }
 
         function groupModeEnumValue(index: int): /*TaskManager.TasksModel.GroupMode*/ int {
             switch (index) {
-            case 0:
-                return TaskManager.TasksModel.GroupDisabled;
-            case 1:
-                return TaskManager.TasksModel.GroupApplications;
+                case 0:
+                    return TaskManager.TasksModel.GroupDisabled;
+                case 1:
+                    return TaskManager.TasksModel.GroupApplications;
             }
         }
 
@@ -453,6 +453,11 @@ PlasmoidItem {
 
     Item {
         anchors.fill: parent
+
+        // Pushes everything down slightly when docked at the absolute bottom
+        transform: Translate {
+            y: (Plasmoid.location === PlasmaCore.Types.BottomEdge) ? 12 : 0
+        }
 
         TaskManager.VirtualDesktopInfo {
             id: virtualDesktopInfo
@@ -693,7 +698,7 @@ PlasmoidItem {
                             return - Kirigami.Units.smallSpacing * 0.8;
 
                         // Panel abajo
-                       return (taskList.height - height) + Kirigami.Units.smallSpacing * 0.6;
+                        return (taskList.height - height) + Kirigami.Units.smallSpacing * 0.6;
                     }
 
                     readonly property int blurRadius:
@@ -806,17 +811,17 @@ PlasmoidItem {
                     : (tasks.skinParams.outBottom || 0))
                 }
 
-              source: {
-                  if (tasks.vertical) {
-                      return tasks.isLeftPanel
-                      ? tasks.skinParams.imageLeft
-                      : tasks.skinParams.imageRight;
-                  }
+                source: {
+                    if (tasks.vertical) {
+                        return tasks.isLeftPanel
+                        ? tasks.skinParams.imageLeft
+                        : tasks.skinParams.imageRight;
+                    }
 
-                  return tasks.isTopPanel
-                  ? tasks.skinParams.imageTop
-                  : tasks.skinParams.imageBottom;
-              }
+                    return tasks.isTopPanel
+                    ? tasks.skinParams.imageTop
+                    : tasks.skinParams.imageBottom;
+                }
 
                 border {
                     left: tasks.vertical
@@ -869,9 +874,9 @@ PlasmoidItem {
 
                     var pos = mapToItem(null, 0, 0);
 
-                /*    if (tasks.vertical && !tasks.isLeftPanel) {
-                        pos = mapToItem(null, - Kirigami.Units.smallSpacing * 3, 0);
-                    } */
+                    /*    if (tasks.vertical && !tasks.isLeftPanel) {
+                     *                       pos = mapToItem(null, - Kirigami.Units.smallSpacing * 3, 0);
+                } */
 
                     backend.setBlurBehind(
                         win,
@@ -918,16 +923,16 @@ PlasmoidItem {
 
             edge: {
                 switch (Plasmoid.location) {
-                case PlasmaCore.Types.BottomEdge:
-                    return Qt.TopEdge;
-                case PlasmaCore.Types.TopEdge:
-                    return Qt.BottomEdge;
-                case PlasmaCore.Types.LeftEdge:
-                    return Qt.RightEdge;
-                case PlasmaCore.Types.RightEdge:
-                    return Qt.LeftEdge;
-                default:
-                    return Qt.TopEdge;
+                    case PlasmaCore.Types.BottomEdge:
+                        return Qt.TopEdge;
+                    case PlasmaCore.Types.TopEdge:
+                        return Qt.BottomEdge;
+                    case PlasmaCore.Types.LeftEdge:
+                        return Qt.RightEdge;
+                    case PlasmaCore.Types.RightEdge:
+                        return Qt.LeftEdge;
+                    default:
+                        return Qt.TopEdge;
                 }
             }
 
@@ -963,33 +968,33 @@ PlasmoidItem {
 
                 property real contentSize: Math.ceil(baseContentSize + zoomExtraSize + spacing * 4)
 
-               readonly property real iconsTotalSize: {
-                   let total = 0;
+                readonly property real iconsTotalSize: {
+                    let total = 0;
 
-                   for (let i = 0; i < taskRepeater.count; ++i) {
-                       let item = taskRepeater.itemAt(i);
+                    for (let i = 0; i < taskRepeater.count; ++i) {
+                        let item = taskRepeater.itemAt(i);
 
-                       if (item) {
+                        if (item) {
 
-                           total += tasks.vertical
-                           ? item.height
-                           : item.width;
+                            total += tasks.vertical
+                            ? item.height
+                            : item.width;
 
-                           if (i > 0)
-                               total += spacing;
-                       }
-                   }
+                            if (i > 0)
+                                total += spacing;
+                        }
+                    }
 
-                   return total;
-               }
+                    return total;
+                }
 
-               readonly property real centerOffset: {
-                   let availableSize = tasks.vertical
-                   ? height
-                   : width;
+                readonly property real centerOffset: {
+                    let availableSize = tasks.vertical
+                    ? height
+                    : width;
 
-                   return (availableSize - iconsTotalSize) / 2;
-               }
+                    return (availableSize - iconsTotalSize) / 2;
+                }
 
                 Layout.maximumWidth: contentSize
                 Layout.maximumHeight: contentSize


### PR DESCRIPTION
## Description
This PR introduces a minor visual adjustment to the dock positioning when it is configured on the `BottomEdge` of the screen. 

Currently, depending on the chosen custom skin or Plasma panel configuration, the dock can sit slightly too high off the bottom screen edge, especially on widescreen setups. Because changing the standard layout anchors or margins often breaks the strict bounding boxes required for the magnifying/zoom animation, I implemented a safe visual offset using a conditional `transform: Translate`.

## Changes Made
- Modified `package/contents/ui/main.qml` to add a dynamic Y-axis translation layer inside the root `Item`.
- The translation shifts the entire element downwards by `12px` strictly when `Plasmoid.location === PlasmaCore.Types.BottomEdge`, pushing it closer to the absolute screen border without breaking layout containment or clipping animations.

## Testing
- Tested locally on KDE Plasma with `Default Plasma` and custom skins.
- Checked side/top panel modes to ensure the translation *only* triggers when the dock is docked on the bottom edge.
- Verified that the zoom/magnification hover effects continue to scale flawlessly without edge clipping.