### PR TITLE
fix: namespace plugin classes to avoid stock task manager collision

### DIFF
--- a/plugin/backend.cpp
+++ b/plugin/backend.cpp
@@ -48,6 +48,8 @@
 #include <unistd.h>
 #include <linux/input.h>
 
+namespace WaveTask
+{
 namespace KAStats = KActivities::Stats;
 
 using namespace KAStats;
@@ -778,5 +780,7 @@ qint64 Backend::parentPid(qint64 pid) const
 
     return -1;
 }
+
+} // namespace WaveTask
 
 #include "moc_backend.cpp"

--- a/plugin/backend.h
+++ b/plugin/backend.h
@@ -34,6 +34,8 @@ namespace KActivities
 class Consumer;
 }
 
+namespace WaveTask
+{
 class Backend : public QObject
 {
     Q_OBJECT
@@ -115,3 +117,5 @@ private:
     QHash<int, InputDeviceMonitor> m_inputMonitors;
     QSet<QString> m_probedPaths;
 };
+
+} // namespace WaveTask

--- a/plugin/smartlauncherbackend.cpp
+++ b/plugin/smartlauncherbackend.cpp
@@ -21,6 +21,8 @@
 #include "log_settings.h"
 #include <settings.h>
 
+namespace WaveTask
+{
 using namespace SmartLauncher;
 using namespace NotificationManager;
 
@@ -247,5 +249,7 @@ void Backend::onServiceUnregistered(const QString &service)
     m_launchers.remove(storageId);
     Q_EMIT launcherRemoved(storageId);
 }
+
+} // namespace WaveTask
 
 #include "moc_smartlauncherbackend.cpp"

--- a/plugin/smartlauncherbackend.h
+++ b/plugin/smartlauncherbackend.h
@@ -21,6 +21,8 @@ namespace NotificationManager
 class Settings;
 }
 
+namespace WaveTask
+{
 namespace SmartLauncher
 {
 struct Entry {
@@ -118,3 +120,5 @@ private:
 };
 
 } // namespace SmartLauncher
+
+} // namespace WaveTask

--- a/plugin/smartlauncheritem.cpp
+++ b/plugin/smartlauncheritem.cpp
@@ -11,6 +11,8 @@
 
 #include "log_settings.h"
 
+namespace WaveTask
+{
 using namespace SmartLauncher;
 
 Item::Item(QObject *parent)
@@ -221,5 +223,7 @@ void Item::setUrgent(bool urgent)
         Q_EMIT urgentChanged(urgent);
     }
 }
+
+} // namespace WaveTask
 
 #include "moc_smartlauncheritem.cpp"

--- a/plugin/smartlauncheritem.h
+++ b/plugin/smartlauncheritem.h
@@ -13,6 +13,8 @@
 
 #include "smartlauncherbackend.h"
 
+namespace WaveTask
+{
 namespace SmartLauncher
 {
 
@@ -80,3 +82,5 @@ private:
 };
 
 } // namespace SmartLauncher
+
+} // namespace WaveTask


### PR DESCRIPTION
If you run WaveTask alongside the stock task manager, right-clicking in the stock side doesn't show the context menu.

WaveTask is a fork of the stock task manager and its plugin kept the class names:
|                | stock `org.kde.plasma.taskmanager`              | `libwavetaskplugin.so`                          |
|----------------|-------------------------------------------------|-------------------------------------------------|
| main backend   | `Backend` (global namespace)                    | `Backend` (global namespace)                    |
| smart launcher | `SmartLauncher::Backend`, `SmartLauncher::Item` | `SmartLauncher::Backend`, `SmartLauncher::Item` |

So i wrapped the plugin's classes in a `WaveTask` namespace:
- `Backend` → `WaveTask::Backend`
- `SmartLauncher::Backend` → `WaveTask::SmartLauncher::Backend`
- `SmartLauncher::Item` → `WaveTask::SmartLauncher::Item`

---

I've been testing it on Plasma `6.7.4`, qt6-base `6.11.2`.